### PR TITLE
 US-3.1 · Dispatch dei Check Schedulati #14

### DIFF
--- a/app/Console/Commands/DispatchChecks.php
+++ b/app/Console/Commands/DispatchChecks.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\PerformCheck;
+use App\Models\Monitor;
+use Illuminate\Console\Command;
+
+class DispatchChecks extends Command
+{
+    protected $signature = 'monitors:dispatch-checks';
+
+    protected $description = 'Dispatch PerformCheck jobs for every monitor that is due for a check.';
+
+    public function handle(): int
+    {
+        $due = Monitor::query()
+            ->where('is_paused', false)
+            ->get()
+            ->filter(fn (Monitor $m) => $this->isDue($m));
+
+        foreach ($due as $monitor) {
+            PerformCheck::dispatch($monitor);
+        }
+
+        $count = $due->count();
+
+        $this->info("Dispatched {$count} check job(s).");
+
+        return self::SUCCESS;
+    }
+
+    private function isDue(Monitor $monitor): bool
+    {
+        if ($monitor->last_checked_at === null) {
+            return true;
+        }
+
+        return $monitor->last_checked_at
+            ->addMinutes($monitor->interval_minutes)
+            ->isPast();
+    }
+}

--- a/app/Jobs/PerformCheck.php
+++ b/app/Jobs/PerformCheck.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Monitor;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class PerformCheck implements ShouldQueue, ShouldBeUnique
+{
+    use Queueable;
+
+    public function __construct(public readonly Monitor $monitor)
+    {
+        $this->onQueue('checks');
+    }
+
+    /**
+     * Prevent duplicate jobs for the same monitor.
+     * The uniqueness lock is held until the job starts processing.
+     */
+    public function uniqueId(): int
+    {
+        return $this->monitor->id;
+    }
+
+    /**
+     * HTTP check logic — implemented in Sprint 3 (US-3.x).
+     */
+    public function handle(): void
+    {
+        // TODO: perform HTTP request and store CheckResult
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,13 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('monitors:dispatch-checks')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->runInBackground();

--- a/tests/Feature/DispatchChecksTest.php
+++ b/tests/Feature/DispatchChecksTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Jobs\PerformCheck;
+use App\Models\Monitor;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function makeMonitor(array $attrs = []): Monitor
+{
+    return Monitor::factory()->create(array_merge([
+        'user_id'          => User::factory(),
+        'interval_minutes' => 5,
+        'is_paused'        => false,
+        'last_checked_at'  => null,
+    ], $attrs));
+}
+
+// ─── Selection logic ──────────────────────────────────────────────────────────
+
+test('dispatches job for monitor never checked', function () {
+    $monitor = makeMonitor(['last_checked_at' => null]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $monitor->id);
+});
+
+test('dispatches job for monitor whose interval has elapsed', function () {
+    $monitor = makeMonitor([
+        'interval_minutes' => 5,
+        'last_checked_at'  => now()->subMinutes(6),
+    ]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $monitor->id);
+});
+
+test('does not dispatch job for monitor checked within its interval', function () {
+    $monitor = makeMonitor([
+        'interval_minutes' => 5,
+        'last_checked_at'  => now()->subMinutes(3),
+    ]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertNotPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $monitor->id);
+});
+
+test('does not dispatch job for paused monitor', function () {
+    $monitor = makeMonitor([
+        'is_paused'       => true,
+        'last_checked_at' => null,
+    ]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertNotPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $monitor->id);
+});
+
+test('dispatches job exactly at interval boundary', function () {
+    $monitor = makeMonitor([
+        'interval_minutes' => 5,
+        'last_checked_at'  => now()->subMinutes(5),
+    ]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $monitor->id);
+});
+
+test('dispatches only due monitors when multiple exist', function () {
+    $due1 = makeMonitor(['last_checked_at' => null]);
+    $due2 = makeMonitor(['interval_minutes' => 2, 'last_checked_at' => now()->subMinutes(3)]);
+    $notDue = makeMonitor(['interval_minutes' => 5, 'last_checked_at' => now()->subMinutes(2)]);
+    $paused = makeMonitor(['is_paused' => true, 'last_checked_at' => null]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertPushed(PerformCheck::class, 2);
+    Queue::assertPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $due1->id);
+    Queue::assertPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $due2->id);
+    Queue::assertNotPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $notDue->id);
+    Queue::assertNotPushed(PerformCheck::class, fn ($job) => $job->monitor->id === $paused->id);
+});
+
+test('job is dispatched to the checks queue', function () {
+    makeMonitor(['last_checked_at' => null]);
+
+    $this->artisan('monitors:dispatch-checks')->assertSuccessful();
+
+    Queue::assertPushedOn('checks', PerformCheck::class);
+});
+
+test('command outputs dispatched count', function () {
+    makeMonitor(['last_checked_at' => null]);
+    makeMonitor(['last_checked_at' => null]);
+
+    $this->artisan('monitors:dispatch-checks')
+        ->expectsOutputToContain('Dispatched 2 check job(s).')
+        ->assertSuccessful();
+});
+
+test('command outputs zero when nothing is due', function () {
+    makeMonitor(['interval_minutes' => 5, 'last_checked_at' => now()->subMinutes(1)]);
+
+    $this->artisan('monitors:dispatch-checks')
+        ->expectsOutputToContain('Dispatched 0 check job(s).')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
- Introduced `DispatchChecks` command to dispatch `PerformCheck` jobs for monitors due for a check.
- Created `PerformCheck` job to handle the check logic, ensuring uniqueness for each monitor.
- Updated console routes to schedule the dispatch command to run every minute.
- Added comprehensive tests for the dispatch command, covering various scenarios for monitor checks.