### PR TITLE
US-4.1 · Notifica Email Monitor Down #19

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(XDEBUG_MODE=off php artisan test)",
       "Bash(php -r \"echo php_ini_loaded_file\\(\\) . PHP_EOL;\")",
       "Bash(php -r \"echo ini_get\\('xdebug.mode'\\) . PHP_EOL;\")",
-      "Bash(php --ini)"
+      "Bash(php --ini)",
+      "Bash(XDEBUG_MODE=off php artisan test --no-coverage)",
+      "Bash(./vendor/bin/pest --no-coverage)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(php -r \"echo ini_get\\('xdebug.mode'\\) . PHP_EOL;\")",
       "Bash(php --ini)",
       "Bash(XDEBUG_MODE=off php artisan test --no-coverage)",
-      "Bash(./vendor/bin/pest --no-coverage)"
+      "Bash(./vendor/bin/pest --no-coverage)",
+      "Bash(./vendor/bin/pest tests/Feature/SendDownNotificationTest.php --no-coverage)"
     ]
   }
 }

--- a/app/Listeners/SendDownNotification.php
+++ b/app/Listeners/SendDownNotification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MonitorStatusChanged;
+use App\Notifications\MonitorDownNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class SendDownNotification implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public string $queue = 'notifications';
+
+    public function handle(MonitorStatusChanged $event): void
+    {
+        if ($event->newStatus !== 'down') {
+            return;
+        }
+
+        $event->monitor->user->notify(new MonitorDownNotification(
+            $event->monitor,
+            $event->checkResult,
+        ));
+    }
+}

--- a/app/Notifications/MonitorDownNotification.php
+++ b/app/Notifications/MonitorDownNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MonitorDownNotification extends Notification
+{
+    public function __construct(
+        public readonly Monitor $monitor,
+        public readonly CheckResult $checkResult,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $statusCode = $this->checkResult->status_code !== null
+            ? (string) $this->checkResult->status_code
+            : 'Connection failed';
+
+        return (new MailMessage)
+            ->subject("[WatchBoard] {$this->monitor->name} is down")
+            ->greeting('Monitor Down Alert')
+            ->line("**{$this->monitor->name}** is not responding.")
+            ->line("**URL:** {$this->monitor->url}")
+            ->line("**Status:** {$statusCode}")
+            ->line("**Detected at:** {$this->checkResult->checked_at->toDateTimeString()} UTC")
+            ->salutation('— WatchBoard');
+    }
+}

--- a/app/Notifications/MonitorDownNotification.php
+++ b/app/Notifications/MonitorDownNotification.php
@@ -4,10 +4,11 @@ namespace App\Notifications;
 
 use App\Models\CheckResult;
 use App\Models\Monitor;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MonitorDownNotification extends Notification
+class MonitorDownNotification extends Notification implements ShouldQueue
 {
     public function __construct(
         public readonly Monitor $monitor,
@@ -16,7 +17,12 @@ class MonitorDownNotification extends Notification
 
     public function via(object $notifiable): array
     {
-        return ['mail'];
+        return ['mail']; // estendibile: ['mail', 'slack', 'vonage', ...]
+    }
+
+    public function viaQueues(): array
+    {
+        return ['mail' => 'notifications'];
     }
 
     public function toMail(object $notifiable): MailMessage

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Events\MonitorStatusChanged;
+use App\Listeners\SendDownNotification;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
@@ -21,5 +24,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Vite::prefetch(concurrency: 3);
+
+        Event::listen(MonitorStatusChanged::class, SendDownNotification::class);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,5 +32,6 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
+        <env name="XDEBUG_MODE" value="off"/>
     </php>
 </phpunit>

--- a/tests/Feature/SendDownNotificationTest.php
+++ b/tests/Feature/SendDownNotificationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Events\MonitorStatusChanged;
+use App\Listeners\SendDownNotification;
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\User;
+use App\Notifications\MonitorDownNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function makeEvent(string $oldStatus, string $newStatus, ?int $statusCode = 500): MonitorStatusChanged
+{
+    $monitor = Monitor::factory()->create([
+        'user_id' => User::factory(),
+    ]);
+
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => $statusCode,
+        'response_time_ms' => 120,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    return new MonitorStatusChanged($monitor, $oldStatus, $newStatus, $checkResult);
+}
+
+// ─── Notification sent ────────────────────────────────────────────────────────
+
+test('sends notification to monitor owner when status goes down', function () {
+    Notification::fake();
+
+    $event = makeEvent('up', 'down');
+    (new SendDownNotification)->handle($event);
+
+    Notification::assertSentTo($event->monitor->user, MonitorDownNotification::class);
+});
+
+test('sends notification on first check when service is already down (unknown → down)', function () {
+    Notification::fake();
+
+    $event = makeEvent('unknown', 'down');
+    (new SendDownNotification)->handle($event);
+
+    Notification::assertSentTo($event->monitor->user, MonitorDownNotification::class);
+});
+
+// ─── Notification not sent ────────────────────────────────────────────────────
+
+test('does not send notification when monitor recovers (down → up)', function () {
+    Notification::fake();
+
+    $event = makeEvent('down', 'up');
+    (new SendDownNotification)->handle($event);
+
+    Notification::assertNothingSent();
+});
+
+// ─── Notification content ─────────────────────────────────────────────────────
+
+test('notification mail contains monitor name, url, status code and timestamp', function () {
+    Notification::fake();
+
+    $monitor = Monitor::factory()->create([
+        'user_id' => User::factory(),
+        'name'    => 'My API',
+        'url'     => 'https://api.example.com',
+    ]);
+
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 503,
+        'response_time_ms' => 200,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
+    (new SendDownNotification)->handle($event);
+
+    Notification::assertSentTo(
+        $monitor->user,
+        MonitorDownNotification::class,
+        function (MonitorDownNotification $notification) use ($monitor, $checkResult) {
+            $mail = $notification->toMail($monitor->user);
+            $rendered = implode(' ', array_column($mail->introLines, 'line') + $mail->introLines);
+
+            return str_contains($mail->subject, $monitor->name)
+                && str_contains($rendered, $monitor->url)
+                && str_contains($rendered, '503')
+                && str_contains($rendered, $checkResult->checked_at->toDateTimeString());
+        }
+    );
+});
+
+test('notification shows "Connection failed" when status code is null', function () {
+    Notification::fake();
+
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => null,
+        'response_time_ms' => 0,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
+    (new SendDownNotification)->handle($event);
+
+    Notification::assertSentTo(
+        $monitor->user,
+        MonitorDownNotification::class,
+        function (MonitorDownNotification $notification) use ($monitor) {
+            $mail = $notification->toMail($monitor->user);
+            $rendered = implode(' ', $mail->introLines);
+
+            return str_contains($rendered, 'Connection failed');
+        }
+    );
+});
+
+// ─── Queue ────────────────────────────────────────────────────────────────────
+
+test('listener is queued on the notifications queue', function () {
+    $listener = new SendDownNotification();
+
+    expect($listener)->toBeInstanceOf(Illuminate\Contracts\Queue\ShouldQueue::class);
+    expect($listener->queue)->toBe('notifications');
+});


### PR DESCRIPTION
- Introduced `SendDownNotification` listener to handle notifications when a monitor's status changes to down.
- Created `MonitorDownNotification` class for email notifications, including relevant monitor details and status codes.
- Updated `AppServiceProvider` to listen for `MonitorStatusChanged` events and trigger notifications.
- Added tests for notification functionality, ensuring correct behavior for various status transitions and notification content.
- Updated PHPUnit configuration and local settings for improved testing environment.