### PR TITLE
US-4.2 · Notifica Email Monitor Recovery #20

### DIFF
--- a/app/Listeners/SendRecoveryNotification.php
+++ b/app/Listeners/SendRecoveryNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MonitorStatusChanged;
+use App\Notifications\MonitorRecoveredNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class SendRecoveryNotification implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public string $queue = 'notifications';
+
+    public function handle(MonitorStatusChanged $event): void
+    {
+        if ($event->oldStatus !== 'down' || $event->newStatus !== 'up') {
+            return;
+        }
+
+        $event->monitor->user->notify(new MonitorRecoveredNotification(
+            $event->monitor,
+            $event->checkResult,
+            $event->downtimeSeconds,
+        ));
+    }
+}

--- a/app/Notifications/MonitorRecoveredNotification.php
+++ b/app/Notifications/MonitorRecoveredNotification.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MonitorRecoveredNotification extends Notification implements ShouldQueue
+{
+    public function __construct(
+        public readonly Monitor $monitor,
+        public readonly CheckResult $checkResult,
+        public readonly ?int $downtimeSeconds,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail']; // estendibile: ['mail', 'slack', 'vonage', ...]
+    }
+
+    public function viaQueues(): array
+    {
+        return ['mail' => 'notifications'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $message = (new MailMessage)
+            ->subject("[WatchBoard] {$this->monitor->name} is back up")
+            ->greeting('Monitor Recovery')
+            ->line("**{$this->monitor->name}** is responding again.")
+            ->line("**URL:** {$this->monitor->url}");
+
+        if ($this->downtimeSeconds !== null) {
+            $message->line("**Downtime:** {$this->formatDowntime($this->downtimeSeconds)}");
+        }
+
+        return $message
+            ->line("**Recovered at:** {$this->checkResult->checked_at->toDateTimeString()} UTC")
+            ->salutation('— WatchBoard');
+    }
+
+    private function formatDowntime(int $seconds): string
+    {
+        if ($seconds < 60) {
+            return "{$seconds}s";
+        }
+
+        $minutes = intdiv($seconds, 60);
+
+        if ($minutes < 60) {
+            $remaining = $seconds % 60;
+            return $remaining > 0 ? "{$minutes}m {$remaining}s" : "{$minutes}m";
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remaining = $minutes % 60;
+
+        return $remaining > 0 ? "{$hours}h {$remaining}m" : "{$hours}h";
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Events\MonitorStatusChanged;
 use App\Listeners\SendDownNotification;
+use App\Listeners\SendRecoveryNotification;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
@@ -26,5 +27,6 @@ class AppServiceProvider extends ServiceProvider
         Vite::prefetch(concurrency: 3);
 
         Event::listen(MonitorStatusChanged::class, SendDownNotification::class);
+        Event::listen(MonitorStatusChanged::class, SendRecoveryNotification::class);
     }
 }

--- a/database/factories/CheckResultFactory.php
+++ b/database/factories/CheckResultFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CheckResult>
+ */
+class CheckResultFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'monitor_id'     => Monitor::first()->id ?? Monitor::factory()->create()->id,
+            'status_code' => fake()->randomElement([
+                // 1xx Informational
+                100,
+                101,
+                102,
+                103,
+                // 2xx Success
+                200,
+                201,
+                202,
+                203,
+                204,
+                205,
+                206,
+                207,
+                208,
+                226,
+                // 3xx Redirection
+                300,
+                301,
+                302,
+                303,
+                304,
+                305,
+                307,
+                308,
+                // 4xx Client Error
+                400,
+                401,
+                402,
+                403,
+                404,
+                405,
+                406,
+                407,
+                408,
+                409,
+                410,
+                411,
+                412,
+                413,
+                414,
+                415,
+                416,
+                417,
+                418,
+                421,
+                422,
+                423,
+                424,
+                425,
+                426,
+                428,
+                429,
+                431,
+                451,
+                // 5xx Server Error
+                500,
+                501,
+                502,
+                503,
+                504,
+                505,
+                506,
+                507,
+                508,
+                510,
+                511,
+            ]),
+            'response_time_ms' => fake()->numberBetween(100, 1000),
+            'is_successful'    => fake()->randomElement([true, false]),
+            'checked_at'       => fake()->dateTimeBetween('-1 week', 'now'),
+        ];
+    }
+}

--- a/tests/Feature/SendRecoveryNotificationTest.php
+++ b/tests/Feature/SendRecoveryNotificationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Events\MonitorStatusChanged;
+use App\Listeners\SendRecoveryNotification;
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\User;
+use App\Notifications\MonitorRecoveredNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Notification;
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function recoveryEvent(?int $downtimeSeconds = 600): MonitorStatusChanged
+{
+    $monitor = Monitor::factory()->create([
+        'user_id' => User::factory(),
+    ]);
+
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 95,
+        'is_successful'    => true,
+        'checked_at'       => now(),
+    ]);
+
+    return new MonitorStatusChanged($monitor, 'down', 'up', $checkResult, $downtimeSeconds);
+}
+
+// ─── Notification sent ────────────────────────────────────────────────────────
+
+test('sends recovery notification to monitor owner when monitor comes back up', function () {
+    Notification::fake();
+
+    $event = recoveryEvent();
+    (new SendRecoveryNotification)->handle($event);
+
+    Notification::assertSentTo($event->monitor->user, MonitorRecoveredNotification::class);
+});
+
+// ─── Notification not sent ────────────────────────────────────────────────────
+
+test('does not send notification when monitor goes down (up → down)', function () {
+    Notification::fake();
+
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 500,
+        'response_time_ms' => 0,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
+    (new SendRecoveryNotification)->handle($event);
+
+    Notification::assertNothingSent();
+});
+
+test('does not send notification on unknown → up', function () {
+    Notification::fake();
+
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    $checkResult = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 80,
+        'is_successful'    => true,
+        'checked_at'       => now(),
+    ]);
+
+    $event = new MonitorStatusChanged($monitor, 'unknown', 'up', $checkResult);
+    (new SendRecoveryNotification)->handle($event);
+
+    Notification::assertNothingSent();
+});
+
+// ─── Notification content ─────────────────────────────────────────────────────
+
+test('notification mail contains monitor name, url, recovery timestamp and downtime', function () {
+    Notification::fake();
+
+    $event = recoveryEvent(downtimeSeconds: 3750); // 1h 2m 30s
+    (new SendRecoveryNotification)->handle($event);
+
+    Notification::assertSentTo(
+        $event->monitor->user,
+        MonitorRecoveredNotification::class,
+        function (MonitorRecoveredNotification $notification) use ($event) {
+            $mail = $notification->toMail($event->monitor->user);
+            $rendered = implode(' ', $mail->introLines);
+
+            return str_contains($mail->subject, $event->monitor->name)
+                && str_contains($rendered, $event->monitor->url)
+                && str_contains($rendered, $event->checkResult->checked_at->toDateTimeString())
+                && str_contains($rendered, '1h 2m'); // downtime formattato
+        }
+    );
+});
+
+test('notification omits downtime line when downtimeSeconds is null', function () {
+    Notification::fake();
+
+    $event = recoveryEvent(downtimeSeconds: null);
+    (new SendRecoveryNotification)->handle($event);
+
+    Notification::assertSentTo(
+        $event->monitor->user,
+        MonitorRecoveredNotification::class,
+        function (MonitorRecoveredNotification $notification) use ($event) {
+            $mail = $notification->toMail($event->monitor->user);
+            $rendered = implode(' ', $mail->introLines);
+
+            return ! str_contains($rendered, 'Downtime');
+        }
+    );
+});
+
+// ─── Downtime formatting ──────────────────────────────────────────────────────
+
+test('formats downtime in seconds when under a minute', function () {
+    $notification = new MonitorRecoveredNotification(
+        Monitor::factory()->make(),
+        CheckResult::factory()->make(),
+        45,
+    );
+
+    $mail = $notification->toMail(User::factory()->make());
+    expect(implode(' ', $mail->introLines))->toContain('45s');
+});
+
+test('formats downtime in minutes when under an hour', function () {
+    $notification = new MonitorRecoveredNotification(
+        Monitor::factory()->make(),
+        CheckResult::factory()->make(),
+        150, // 2m 30s
+    );
+
+    $mail = $notification->toMail(User::factory()->make());
+    expect(implode(' ', $mail->introLines))->toContain('2m 30s');
+});
+
+test('formats downtime in hours and minutes when over an hour', function () {
+    $notification = new MonitorRecoveredNotification(
+        Monitor::factory()->make(),
+        CheckResult::factory()->make(),
+        5400, // 1h 30m
+    );
+
+    $mail = $notification->toMail(User::factory()->make());
+    expect(implode(' ', $mail->introLines))->toContain('1h 30m');
+});
+
+// ─── Queue ────────────────────────────────────────────────────────────────────
+
+test('listener is queued on the notifications queue', function () {
+    $listener = new SendRecoveryNotification();
+
+    expect($listener)->toBeInstanceOf(ShouldQueue::class);
+    expect($listener->queue)->toBe('notifications');
+});


### PR DESCRIPTION
- Introduced `SendRecoveryNotification` listener to handle notifications when a monitor's status changes from down to up.
- Created `MonitorRecoveredNotification` class for email notifications, including relevant monitor details and downtime information.
- Updated `AppServiceProvider` to listen for `MonitorStatusChanged` events and trigger recovery notifications.
- Added tests to ensure correct notification behavior and content for various status transitions.