### PR TITLE
 US-1.2 · Sistema piani Free/Pro #2

### DIFF
--- a/app/Http/Middleware/CheckPlanLimits.php
+++ b/app/Http/Middleware/CheckPlanLimits.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckPlanLimits
+{
+    public function handle(Request $request, Closure $next, string $resource): Response
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return $next($request);
+        }
+
+        $configKey = match ($resource) {
+            'monitors' => 'max_monitors',
+            'status-pages' => 'max_status_pages',
+            default => null,
+        };
+
+        if ($configKey === null) {
+            abort(500, "Unknown plan limited resource [{$resource}].");
+        }
+
+        $maxAllowed = $user->planConfig()[$configKey] ?? null;
+
+        // Null means unlimited for the current plan.
+        if ($maxAllowed === null) {
+            return $next($request);
+        }
+
+        $relationship = match ($resource) {
+            'monitors' => 'monitors',
+            'status-pages' => 'statusPages',
+        };
+
+        if (! method_exists($user, $relationship)) {
+            return $next($request);
+        }
+
+        if ($user->{$relationship}()->count() >= $maxAllowed) {
+            abort(403, 'Plan limit reached for this feature.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests;
 
 use App\Models\Monitor;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class StoreMonitorRequest extends FormRequest
 {
@@ -15,11 +14,13 @@ class StoreMonitorRequest extends FormRequest
 
     public function rules(): array
     {
+        $minimumInterval = (int) $this->user()->planConfig()['min_interval_minutes'];
+
         return [
             'name'             => ['nullable', 'string', 'max:255'],
             'url'              => ['required', 'url', 'max:2048'],
             'method'           => ['required', 'in:GET,HEAD'],
-            'interval_minutes' => ['required', Rule::in($this->user()->planConfig()['intervals'])],
+            'interval_minutes' => ['required', 'integer', 'min:'.$minimumInterval],
         ];
     }
 }

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests;
 
 use App\Models\Monitor;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class UpdateMonitorRequest extends FormRequest
 {
@@ -15,11 +14,13 @@ class UpdateMonitorRequest extends FormRequest
 
     public function rules(): array
     {
+        $minimumInterval = (int) $this->user()->planConfig()['min_interval_minutes'];
+
         return [
             'name'             => ['nullable', 'string', 'max:255'],
             'url'              => ['required', 'url', 'max:2048'],
             'method'           => ['required', 'in:GET,HEAD'],
-            'interval_minutes' => ['required', Rule::in($this->user()->planConfig()['intervals'])],
+            'interval_minutes' => ['required', 'integer', 'min:'.$minimumInterval],
         ];
     }
 }

--- a/app/Policies/MonitorPolicy.php
+++ b/app/Policies/MonitorPolicy.php
@@ -9,7 +9,13 @@ class MonitorPolicy
 {
     public function create(User $user): bool
     {
-        return $user->monitors()->count() < $user->planConfig()['max_monitors'];
+        $maxMonitors = $user->planConfig()['max_monitors'];
+
+        if ($maxMonitors === null) {
+            return true;
+        }
+
+        return $user->monitors()->count() < $maxMonitors;
     }
 
     public function view(User $user, Monitor $monitor): bool

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,7 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->alias([
+            'check.plan.limits' => \App\Http\Middleware\CheckPlanLimits::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/plans.php
+++ b/config/plans.php
@@ -2,11 +2,15 @@
 
 return [
     'free' => [
-        'max_monitors' => 3,
-        'intervals'    => [5],
+        'max_monitors'         => 5,
+        'min_interval_minutes' => 5,
+        'max_status_pages'     => 1,
+        'intervals'            => [5],
     ],
     'pro' => [
-        'max_monitors' => 10,
-        'intervals'    => [1, 2, 3, 5],
+        'max_monitors'         => null,
+        'min_interval_minutes' => 1,
+        'max_status_pages'     => null,
+        'intervals'            => [1, 2, 3, 5],
     ],
 ];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,11 +15,22 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        User::factory()->create([
+            'name' => 'Demo Free User',
+            'email' => 'demo-free@example.com',
+            'plan' => 'free',
+        ]);
+
+        User::factory()->create([
+            'name' => 'Demo Pro User',
+            'email' => 'demo-pro@example.com',
+            'plan' => 'pro',
+        ]);
 
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'plan' => 'free',
         ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,9 @@ Route::get('/', function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [MonitorController::class, 'index'])->name('dashboard');
     Route::get('/monitors/create', [MonitorController::class, 'create'])->name('monitors.create');
-    Route::post('/monitors', [MonitorController::class, 'store'])->name('monitors.store');
+    Route::post('/monitors', [MonitorController::class, 'store'])
+        ->middleware('check.plan.limits:monitors')
+        ->name('monitors.store');
     Route::get('/monitors/{monitor}', [MonitorController::class, 'show'])->name('monitors.show');
     Route::get('/monitors/{monitor}/edit', [MonitorController::class, 'edit'])->name('monitors.edit');
     Route::put('/monitors/{monitor}', [MonitorController::class, 'update'])->name('monitors.update');

--- a/tests/Feature/MonitorCrudTest.php
+++ b/tests/Feature/MonitorCrudTest.php
@@ -24,7 +24,7 @@ test('authenticated user can view the dashboard', function () {
     $this->actingAs($user)
         ->get(route('dashboard'))
         ->assertOk()
-        ->assertInertia(fn ($page) => $page->component('Dashboard'));
+        ->assertInertia(fn($page) => $page->component('Dashboard'));
 });
 
 test('guest is redirected from dashboard', function () {
@@ -37,7 +37,7 @@ test('user can view the create monitor form', function () {
     $this->actingAs(freeUser())
         ->get(route('monitors.create'))
         ->assertOk()
-        ->assertInertia(fn ($page) => $page->component('Monitors/Create'));
+        ->assertInertia(fn($page) => $page->component('Monitors/Create'));
 });
 
 test('user can create a monitor with valid data', function () {
@@ -77,8 +77,7 @@ test('store fails with invalid method', function () {
         ->assertSessionHasErrors('method');
 });
 
-test('store fails with interval not available on plan', function () {
-    // free plan only allows interval 5
+test('store fails with interval below free plan minimum', function () {
     $this->actingAs(freeUser())
         ->post(route('monitors.store'), [
             'url'              => 'https://example.com',
@@ -90,9 +89,9 @@ test('store fails with interval not available on plan', function () {
 
 // ─── Plan limit ───────────────────────────────────────────────────────────────
 
-test('free user cannot create a 4th monitor (plan limit)', function () {
+test('free user cannot create a 6th monitor (plan limit)', function () {
     $user = freeUser();
-    Monitor::factory()->count(3)->forUser($user)->withInterval(5)->create();
+    Monitor::factory()->count(5)->forUser($user)->withInterval(5)->create();
 
     $this->actingAs($user)
         ->post(route('monitors.store'), [
@@ -103,9 +102,9 @@ test('free user cannot create a 4th monitor (plan limit)', function () {
         ->assertForbidden();
 });
 
-test('pro user can create up to 10 monitors', function () {
+test('pro user can create monitors without limit', function () {
     $user = proUser();
-    Monitor::factory()->count(9)->forUser($user)->withInterval(5)->create();
+    Monitor::factory()->count(25)->forUser($user)->withInterval(5)->create();
 
     $this->actingAs($user)
         ->post(route('monitors.store'), [
@@ -115,7 +114,7 @@ test('pro user can create up to 10 monitors', function () {
         ])
         ->assertRedirect(route('dashboard'));
 
-    expect($user->monitors()->count())->toBe(10);
+    expect($user->monitors()->count())->toBe(26);
 });
 
 // ─── Edit ─────────────────────────────────────────────────────────────────────
@@ -127,10 +126,11 @@ test('owner can view the edit form pre-populated', function () {
     $this->actingAs($user)
         ->get(route('monitors.edit', $monitor))
         ->assertOk()
-        ->assertInertia(fn ($page) => $page
-            ->component('Monitors/Edit')
-            ->has('monitor')
-            ->where('monitor.id', $monitor->id)
+        ->assertInertia(
+            fn($page) => $page
+                ->component('Monitors/Edit')
+                ->has('monitor')
+                ->where('monitor.id', $monitor->id)
         );
 });
 


### PR DESCRIPTION
- Introduced `CheckPlanLimits` middleware to enforce user plan limits on monitor creation.
- Updated `StoreMonitorRequest` and `UpdateMonitorRequest` to validate interval minutes based on user plan configuration.
- Enhanced `MonitorPolicy` to check maximum monitor limits for user plans.
- Updated routes to apply the new middleware for monitor creation.
- Modified plan configuration to include minimum interval settings and adjusted limits for free and pro plans.
- Added demo users in the database seeder for testing plan limits.