### PR TITLE
US-5.1 · Grafico Response Time #22

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,10 @@
       "Bash(php --ini)",
       "Bash(XDEBUG_MODE=off php artisan test --no-coverage)",
       "Bash(./vendor/bin/pest --no-coverage)",
-      "Bash(./vendor/bin/pest tests/Feature/SendDownNotificationTest.php --no-coverage)"
+      "Bash(./vendor/bin/pest tests/Feature/SendDownNotificationTest.php --no-coverage)",
+      "Bash(grep -E \"\\\\.\\(jsx|tsx|js\\)$\")",
+      "Bash(npm install:*)",
+      "Bash(./vendor/bin/pest tests/Feature/MonitorMetricsTest.php --no-coverage)"
     ]
   }
 }

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -5,9 +5,11 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreMonitorRequest;
 use App\Http\Requests\UpdateMonitorRequest;
 use App\Models\Monitor;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -107,5 +109,44 @@ class MonitorController extends Controller
 
         return redirect()->route('dashboard')
             ->with('message', 'Monitor eliminato con successo.');
+    }
+
+    public function metrics(Request $request, Monitor $monitor): JsonResponse
+    {
+        Gate::authorize('view', $monitor);
+
+        $validated = $request->validate([
+            'range' => ['sometimes', Rule::in(['24h', '7d', '30d'])],
+        ]);
+
+        $range = $validated['range'] ?? '24h';
+
+        $since = match ($range) {
+            '24h' => now()->subHours(24),
+            '7d'  => now()->subDays(7),
+            '30d' => now()->subDays(30),
+        };
+
+        $results = $monitor->checkResults()
+            ->where('checked_at', '>=', $since)
+            ->orderBy('checked_at')
+            ->get(['response_time_ms', 'checked_at']);
+
+        $data = $results
+            ->groupBy(function ($r) {
+                $bucket = intdiv($r->checked_at->minute, 15) * 15;
+
+                return $r->checked_at->copy()
+                    ->setTime($r->checked_at->hour, $bucket, 0)
+                    ->toIso8601String();
+            })
+            ->map(fn ($group, $key) => [
+                'timestamp'            => $key,
+                'avg_response_time_ms' => (int) round($group->avg('response_time_ms')),
+                'check_count'          => $group->count(),
+            ])
+            ->values();
+
+        return response()->json(['data' => $data]);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@vue/server-renderer": "^3.4.0",
                 "autoprefixer": "^10.4.12",
                 "axios": ">=1.11.0 <=1.14.0",
+                "chart.js": "^4.5.1",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^3.0.0",
                 "postcss": "^8.4.31",
@@ -19,6 +20,7 @@
                 "typescript": "^5.6.3",
                 "vite": "^8.0.0",
                 "vue": "^3.4.0",
+                "vue-chartjs": "^5.3.3",
                 "vue-tsc": "^2.0.24"
             }
         },
@@ -183,6 +185,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "dev": true
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.3",
@@ -1252,6 +1260,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "dev": true,
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -3210,6 +3230,16 @@
                 }
             }
         },
+        "node_modules/vue-chartjs": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+            "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+            "dev": true,
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "vue": "^3.0.0-0 || ^2.7.0"
+            }
+        },
         "node_modules/vue-tsc": {
             "version": "2.2.12",
             "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
@@ -3415,6 +3445,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "dev": true
         },
         "@napi-rs/wasm-runtime": {
             "version": "1.1.3",
@@ -4093,6 +4129,15 @@
                         "has-flag": "^4.0.0"
                     }
                 }
+            }
+        },
+        "chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "dev": true,
+            "requires": {
+                "@kurkle/color": "^0.3.0"
             }
         },
         "chokidar": {
@@ -5286,6 +5331,13 @@
                 "@vue/server-renderer": "3.5.32",
                 "@vue/shared": "3.5.32"
             }
+        },
+        "vue-chartjs": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+            "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+            "dev": true,
+            "requires": {}
         },
         "vue-tsc": {
             "version": "2.2.12",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "@vue/server-renderer": "^3.4.0",
         "autoprefixer": "^10.4.12",
         "axios": ">=1.11.0 <=1.14.0",
+        "chart.js": "^4.5.1",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.0.0",
         "postcss": "^8.4.31",
@@ -21,6 +22,7 @@
         "typescript": "^5.6.3",
         "vite": "^8.0.0",
         "vue": "^3.4.0",
+        "vue-chartjs": "^5.3.3",
         "vue-tsc": "^2.0.24"
     }
 }

--- a/resources/js/Pages/Monitors/Show.vue
+++ b/resources/js/Pages/Monitors/Show.vue
@@ -4,7 +4,21 @@ import DangerButton from '@/Components/DangerButton.vue';
 import Modal from '@/Components/Modal.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import { Head, Link, useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { ref, onMounted, watch } from 'vue';
+import { Line } from 'vue-chartjs';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Filler,
+} from 'chart.js';
+import axios from 'axios';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Filler);
 
 interface Monitor {
     id: number;
@@ -15,6 +29,14 @@ interface Monitor {
     current_status: 'unknown' | 'up' | 'down';
     is_paused: boolean;
 }
+
+interface MetricPoint {
+    timestamp: string;
+    avg_response_time_ms: number;
+    check_count: number;
+}
+
+type Range = '24h' | '7d' | '30d';
 
 const props = defineProps<{
     monitor: Monitor;
@@ -28,6 +50,88 @@ const confirmDelete = () => {
         onSuccess: () => { showDeleteModal.value = false; },
     });
 };
+
+// ─── Metrics ──────────────────────────────────────────────────────────────────
+
+const selectedRange = ref<Range>('24h');
+const metrics = ref<MetricPoint[]>([]);
+const loading = ref(true);
+
+const ranges: { value: Range; label: string }[] = [
+    { value: '24h', label: '24h' },
+    { value: '7d', label: '7 giorni' },
+    { value: '30d', label: '30 giorni' },
+];
+
+async function fetchMetrics() {
+    loading.value = true;
+    try {
+        const { data } = await axios.get(
+            route('monitors.metrics', props.monitor.id),
+            { params: { range: selectedRange.value } },
+        );
+        metrics.value = data.data;
+    } finally {
+        loading.value = false;
+    }
+}
+
+onMounted(fetchMetrics);
+watch(selectedRange, fetchMetrics);
+
+function formatLabel(iso: string): string {
+    const d = new Date(iso);
+    if (selectedRange.value === '24h') {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    return d.toLocaleDateString([], { day: '2-digit', month: '2-digit' })
+        + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+const chartData = ref<any>({ labels: [], datasets: [] });
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { intersect: false, mode: 'index' as const },
+    plugins: {
+        tooltip: {
+            callbacks: {
+                label: (ctx: any) => `${ctx.parsed.y} ms`,
+            },
+        },
+        legend: { display: false },
+    },
+    scales: {
+        x: {
+            ticks: { maxTicksLimit: 12, maxRotation: 0, color: '#9ca3af' },
+            grid: { display: false },
+        },
+        y: {
+            beginAtZero: true,
+            ticks: {
+                callback: (v: any) => `${v} ms`,
+                color: '#9ca3af',
+            },
+            grid: { color: 'rgba(156,163,175,0.15)' },
+        },
+    },
+};
+
+watch(metrics, (pts) => {
+    chartData.value = {
+        labels: pts.map(p => formatLabel(p.timestamp)),
+        datasets: [{
+            data: pts.map(p => p.avg_response_time_ms),
+            borderColor: '#6366f1',
+            backgroundColor: 'rgba(99,102,241,0.08)',
+            borderWidth: 2,
+            pointRadius: pts.length > 100 ? 0 : 2,
+            pointHoverRadius: 4,
+            tension: 0.3,
+            fill: true,
+        }],
+    };
+}, { immediate: true });
 </script>
 
 <template>
@@ -65,49 +169,89 @@ const confirmDelete = () => {
         </template>
 
         <div class="py-12">
-            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
-                    <div class="flex flex-col items-center justify-center py-20 text-center">
-                        <svg
-                            class="mb-4 h-12 w-12 text-gray-300 dark:text-gray-600"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
-                            />
-                        </svg>
-                        <p class="text-base font-medium text-gray-500 dark:text-gray-400">
-                            Dettaglio monitor
-                        </p>
-                        <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
-                            Grafici e storico check disponibili nei prossimi sprint.
-                        </p>
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-6">
 
-                        <dl class="mt-8 grid grid-cols-2 gap-x-8 gap-y-4 text-sm sm:grid-cols-4">
-                            <div class="text-left">
-                                <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">URL</dt>
-                                <dd class="mt-1 truncate max-w-[180px] text-gray-700 dark:text-gray-200">{{ monitor.url }}</dd>
-                            </div>
-                            <div class="text-left">
-                                <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Metodo</dt>
-                                <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ monitor.method }}</dd>
-                            </div>
-                            <div class="text-left">
-                                <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Intervallo</dt>
-                                <dd class="mt-1 text-gray-700 dark:text-gray-200">
-                                    {{ monitor.interval_minutes === 1 ? '1 minuto' : `${monitor.interval_minutes} minuti` }}
-                                </dd>
-                            </div>
-                            <div class="text-left">
-                                <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Stato</dt>
-                                <dd class="mt-1 capitalize text-gray-700 dark:text-gray-200">{{ monitor.current_status }}</dd>
-                            </div>
-                        </dl>
+                <!-- Monitor info -->
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <dl class="grid grid-cols-2 gap-x-8 gap-y-4 p-6 text-sm sm:grid-cols-4">
+                        <div>
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">URL</dt>
+                            <dd class="mt-1 truncate max-w-[220px] text-gray-700 dark:text-gray-200">{{ monitor.url }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Metodo</dt>
+                            <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ monitor.method }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Intervallo</dt>
+                            <dd class="mt-1 text-gray-700 dark:text-gray-200">
+                                {{ monitor.interval_minutes === 1 ? '1 minuto' : `${monitor.interval_minutes} minuti` }}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Stato</dt>
+                            <dd class="mt-1">
+                                <span
+                                    class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize"
+                                    :class="{
+                                        'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400': monitor.current_status === 'up',
+                                        'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400': monitor.current_status === 'down',
+                                        'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400': monitor.current_status === 'unknown',
+                                    }"
+                                >
+                                    {{ monitor.current_status }}
+                                </span>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+
+                <!-- Response time chart -->
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800 p-6">
+                    <div class="flex items-center justify-between mb-6">
+                        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200">
+                            Response Time
+                        </h3>
+                        <div class="flex gap-1">
+                            <button
+                                v-for="r in ranges"
+                                :key="r.value"
+                                @click="selectedRange = r.value"
+                                class="rounded-md px-3 py-1 text-xs font-medium transition"
+                                :class="selectedRange === r.value
+                                    ? 'bg-indigo-600 text-white'
+                                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'"
+                            >
+                                {{ r.label }}
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Loading -->
+                    <div v-if="loading" class="flex items-center justify-center h-64">
+                        <svg class="animate-spin h-6 w-6 text-indigo-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                    </div>
+
+                    <!-- Empty state -->
+                    <div v-else-if="metrics.length === 0" class="flex flex-col items-center justify-center h-64 text-center">
+                        <svg class="mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+                        </svg>
+                        <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+                            Nessun dato disponibile
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            I dati appariranno dopo i primi check.
+                        </p>
+                    </div>
+
+                    <!-- Chart -->
+                    <div v-else class="h-64">
+                        <Line :data="chartData" :options="chartOptions" />
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->middleware('check.plan.limits:monitors')
         ->name('monitors.store');
     Route::get('/monitors/{monitor}', [MonitorController::class, 'show'])->name('monitors.show');
+    Route::get('/monitors/{monitor}/metrics', [MonitorController::class, 'metrics'])->name('monitors.metrics');
     Route::get('/monitors/{monitor}/edit', [MonitorController::class, 'edit'])->name('monitors.edit');
     Route::put('/monitors/{monitor}', [MonitorController::class, 'update'])->name('monitors.update');
     Route::delete('/monitors/{monitor}', [MonitorController::class, 'destroy'])->name('monitors.destroy');

--- a/tests/Feature/MonitorMetricsTest.php
+++ b/tests/Feature/MonitorMetricsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\User;
+
+test('returns aggregated response times for a monitor', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 100,
+        'is_successful'    => true,
+        'checked_at'       => now()->subMinutes(10),
+    ]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 200,
+        'is_successful'    => true,
+        'checked_at'       => now()->subMinutes(5),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', $monitor));
+
+    $response->assertOk()
+        ->assertJsonStructure(['data' => [['timestamp', 'avg_response_time_ms', 'check_count']]]);
+
+    $total = collect($response->json('data'))->sum('check_count');
+    expect($total)->toBe(2);
+});
+
+test('aggregates into 15-minute buckets', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $baseTime = now()->startOfHour();
+
+    // Two results in the same 15-min bucket (minute 0-14)
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 100,
+        'is_successful'    => true,
+        'checked_at'       => $baseTime->copy()->addMinutes(2),
+    ]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 200,
+        'is_successful'    => true,
+        'checked_at'       => $baseTime->copy()->addMinutes(10),
+    ]);
+
+    // One result in a different bucket (minute 15-29)
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 300,
+        'is_successful'    => true,
+        'checked_at'       => $baseTime->copy()->addMinutes(20),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', $monitor));
+
+    $data = $response->json('data');
+
+    expect($data)->toHaveCount(2);
+    // First bucket: avg of 100 and 200
+    expect($data[0]['avg_response_time_ms'])->toBe(150);
+    expect($data[0]['check_count'])->toBe(2);
+    // Second bucket: just 300
+    expect($data[1]['avg_response_time_ms'])->toBe(300);
+    expect($data[1]['check_count'])->toBe(1);
+});
+
+test('filters by 24h range by default', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    // Within 24h
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 100,
+        'is_successful'    => true,
+        'checked_at'       => now()->subHours(12),
+    ]);
+
+    // Outside 24h
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 999,
+        'is_successful'    => true,
+        'checked_at'       => now()->subHours(25),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', $monitor));
+
+    $total = collect($response->json('data'))->sum('check_count');
+    expect($total)->toBe(1);
+});
+
+test('supports 7d range', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 100,
+        'is_successful'    => true,
+        'checked_at'       => now()->subDays(3),
+    ]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 200,
+        'is_successful'    => true,
+        'checked_at'       => now()->subDays(8),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', [$monitor, 'range' => '7d']));
+
+    $total = collect($response->json('data'))->sum('check_count');
+    expect($total)->toBe(1);
+});
+
+test('supports 30d range', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 100,
+        'is_successful'    => true,
+        'checked_at'       => now()->subDays(20),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', [$monitor, 'range' => '30d']));
+
+    $total = collect($response->json('data'))->sum('check_count');
+    expect($total)->toBe(1);
+});
+
+test('rejects invalid range', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->getJson(route('monitors.metrics', [$monitor, 'range' => '1y']))
+        ->assertUnprocessable();
+});
+
+test('non-owner cannot access metrics', function () {
+    $owner   = User::factory()->create();
+    $other   = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($other)
+        ->getJson(route('monitors.metrics', $monitor))
+        ->assertForbidden();
+});
+
+test('guest cannot access metrics', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    $this->getJson(route('monitors.metrics', $monitor))
+        ->assertUnauthorized();
+});
+
+test('returns empty data for monitor with no check results', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('monitors.metrics', $monitor));
+
+    $response->assertOk()
+        ->assertJson(['data' => []]);
+});


### PR DESCRIPTION
- Implemented a new `metrics` method in `MonitorController` to aggregate and return response times for a monitor over specified time ranges (24h, 7d, 30d).
- Updated routes to include the new metrics endpoint.
- Enhanced the `Show.vue` component to fetch and display response time data using `vue-chartjs`.
- Added tests for the metrics functionality, ensuring correct data aggregation and access control for users.
- Updated package dependencies to include `chart.js` and `vue-chartjs` for chart rendering.