### PR TITLE
US-5.2 · Percentuale Uptime #23

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(./vendor/bin/pest tests/Feature/SendDownNotificationTest.php --no-coverage)",
       "Bash(grep -E \"\\\\.\\(jsx|tsx|js\\)$\")",
       "Bash(npm install:*)",
-      "Bash(./vendor/bin/pest tests/Feature/MonitorMetricsTest.php --no-coverage)"
+      "Bash(./vendor/bin/pest tests/Feature/MonitorMetricsTest.php --no-coverage)",
+      "Bash(./vendor/bin/pest tests/Feature/UptimeCalculationTest.php --no-coverage)"
     ]
   }
 }

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -34,6 +34,7 @@ class MonitorController extends Controller
                 'last_status_code'      => $monitor->latestCheckResult?->status_code,
                 'last_response_time_ms' => $monitor->latestCheckResult?->response_time_ms,
                 'last_checked_at_human' => $monitor->latestCheckResult?->checked_at?->diffForHumans(),
+                'uptime_24h'            => $monitor->uptimePercentage('24h'),
             ]);
 
         return Inertia::render('Dashboard', [
@@ -72,6 +73,7 @@ class MonitorController extends Controller
                 'current_status'   => $monitor->current_status,
                 'is_paused'        => $monitor->is_paused,
             ],
+            'uptime' => $monitor->uptimeAll(),
         ]);
     }
 

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Cache;
 
 class Monitor extends Model
 {
@@ -44,5 +45,39 @@ class Monitor extends Model
     public function latestCheckResult(): HasOne
     {
         return $this->hasOne(CheckResult::class)->latestOfMany('checked_at');
+    }
+
+    public function uptimePercentage(string $range): ?float
+    {
+        $cacheKey = "monitor:{$this->id}:uptime:{$range}";
+
+        return Cache::remember($cacheKey, 300, function () use ($range) {
+            $since = match ($range) {
+                '24h' => now()->subHours(24),
+                '7d'  => now()->subDays(7),
+                '30d' => now()->subDays(30),
+            };
+
+            $query = $this->checkResults()->where('checked_at', '>=', $since);
+
+            $total = $query->count();
+
+            if ($total === 0) {
+                return null;
+            }
+
+            $successful = (clone $query)->where('is_successful', true)->count();
+
+            return round(($successful / $total) * 100, 2);
+        });
+    }
+
+    public function uptimeAll(): array
+    {
+        return [
+            '24h' => $this->uptimePercentage('24h'),
+            '7d'  => $this->uptimePercentage('7d'),
+            '30d' => $this->uptimePercentage('30d'),
+        ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#34d399,#fbbf24\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"php artisan horizon\" \"php artisan schedule:work\" \"npm run dev\" --names=server,queue,logs,horizon,schedule,vite --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi",

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -14,6 +14,7 @@ interface Monitor {
     last_status_code: number | null;
     last_response_time_ms: number | null;
     last_checked_at_human: string | null;
+    uptime_24h: number | null;
 }
 
 defineProps<{
@@ -39,6 +40,13 @@ const statusConfig: Record<string, { label: string; dot: string; badge: string }
         badge: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
     },
 };
+
+function uptimeBadgeClass(uptime: number | null): string {
+    if (uptime === null) return 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
+    if (uptime >= 99) return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+    if (uptime >= 95) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
+    return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+}
 
 function getStatus(monitor: Monitor) {
     if (monitor.is_paused) {
@@ -130,6 +138,7 @@ function getStatus(monitor: Monitor) {
                                 <tr>
                                     <th class="px-6 py-3">Nome / URL</th>
                                     <th class="px-6 py-3">Stato</th>
+                                    <th class="px-6 py-3">Uptime 24h</th>
                                     <th class="px-6 py-3">Status code</th>
                                     <th class="px-6 py-3">Resp. time</th>
                                     <th class="px-6 py-3">Ultimo check</th>
@@ -158,6 +167,15 @@ function getStatus(monitor: Monitor) {
                                         <span :class="['inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium', getStatus(monitor).badge]">
                                             <span :class="['h-1.5 w-1.5 rounded-full', getStatus(monitor).dot]" />
                                             {{ getStatus(monitor).label }}
+                                        </span>
+                                    </td>
+
+                                    <!-- Uptime 24h -->
+                                    <td class="px-6 py-4">
+                                        <span
+                                            :class="['inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium', uptimeBadgeClass(monitor.uptime_24h)]"
+                                        >
+                                            {{ monitor.uptime_24h !== null ? `${monitor.uptime_24h}%` : '—' }}
                                         </span>
                                     </td>
 

--- a/resources/js/Pages/Monitors/Show.vue
+++ b/resources/js/Pages/Monitors/Show.vue
@@ -38,9 +38,23 @@ interface MetricPoint {
 
 type Range = '24h' | '7d' | '30d';
 
+interface Uptime {
+    '24h': number | null;
+    '7d': number | null;
+    '30d': number | null;
+}
+
 const props = defineProps<{
     monitor: Monitor;
+    uptime: Uptime;
 }>();
+
+function uptimeBadgeClass(value: number | null): string {
+    if (value === null) return 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
+    if (value >= 99) return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+    if (value >= 95) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
+    return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+}
 
 const showDeleteModal = ref(false);
 const deleteForm = useForm({});
@@ -204,6 +218,22 @@ watch(metrics, (pts) => {
                             </dd>
                         </div>
                     </dl>
+                </div>
+
+                <!-- Uptime -->
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <div class="grid grid-cols-3 divide-x divide-gray-100 dark:divide-gray-700">
+                        <div v-for="(label, key) in { '24h': '24 ore', '7d': '7 giorni', '30d': '30 giorni' }" :key="key" class="px-6 py-5 text-center">
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Uptime {{ label }}</dt>
+                            <dd class="mt-2">
+                                <span
+                                    :class="['inline-flex rounded-full px-3 py-1 text-sm font-semibold', uptimeBadgeClass(uptime[key as keyof Uptime])]"
+                                >
+                                    {{ uptime[key as keyof Uptime] !== null ? `${uptime[key as keyof Uptime]}%` : '—' }}
+                                </span>
+                            </dd>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Response time chart -->

--- a/tests/Feature/UptimeCalculationTest.php
+++ b/tests/Feature/UptimeCalculationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function createChecks(Monitor $monitor, int $successful, int $failed, string $age = '1 hour'): void
+{
+    for ($i = 0; $i < $successful; $i++) {
+        CheckResult::create([
+            'monitor_id'       => $monitor->id,
+            'status_code'      => 200,
+            'response_time_ms' => 100,
+            'is_successful'    => true,
+            'checked_at'       => now()->sub($age)->addMinutes($i),
+        ]);
+    }
+
+    for ($i = 0; $i < $failed; $i++) {
+        CheckResult::create([
+            'monitor_id'       => $monitor->id,
+            'status_code'      => 500,
+            'response_time_ms' => 0,
+            'is_successful'    => false,
+            'checked_at'       => now()->sub($age)->addMinutes($successful + $i),
+        ]);
+    }
+}
+
+// ─── Calculation ──────────────────────────────────────────────────────────────
+
+test('calculates uptime percentage correctly', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 9, failed: 1, age: '2 hours');
+
+    expect($monitor->uptimePercentage('24h'))->toBe(90.0);
+});
+
+test('returns 100% when all checks are successful', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 10, failed: 0, age: '2 hours');
+
+    expect($monitor->uptimePercentage('24h'))->toBe(100.0);
+});
+
+test('returns 0% when all checks failed', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 0, failed: 10, age: '2 hours');
+
+    expect($monitor->uptimePercentage('24h'))->toBe(0.0);
+});
+
+test('returns null when no checks exist', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    expect($monitor->uptimePercentage('24h'))->toBeNull();
+});
+
+test('rounds to 2 decimal places', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 2, failed: 1, age: '2 hours');
+
+    // 2/3 = 66.666... → 66.67
+    expect($monitor->uptimePercentage('24h'))->toBe(66.67);
+});
+
+// ─── Range filtering ─────────────────────────────────────────────────────────
+
+test('24h range only includes checks from last 24 hours', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    // Recent: 9 successful
+    createChecks($monitor, successful: 9, failed: 0, age: '2 hours');
+
+    // Old: 1 failed (outside 24h window)
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 500,
+        'response_time_ms' => 0,
+        'is_successful'    => false,
+        'checked_at'       => now()->subHours(25),
+    ]);
+
+    expect($monitor->uptimePercentage('24h'))->toBe(100.0);
+});
+
+test('7d range includes checks from last 7 days', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    createChecks($monitor, successful: 9, failed: 1, age: '3 days');
+
+    expect($monitor->uptimePercentage('7d'))->toBe(90.0);
+});
+
+test('30d range includes checks from last 30 days', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+
+    createChecks($monitor, successful: 19, failed: 1, age: '20 days');
+
+    expect($monitor->uptimePercentage('30d'))->toBe(95.0);
+});
+
+// ─── uptimeAll ────────────────────────────────────────────────────────────────
+
+test('uptimeAll returns all three periods', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 10, failed: 0, age: '2 hours');
+
+    $result = $monitor->uptimeAll();
+
+    expect($result)->toHaveKeys(['24h', '7d', '30d']);
+    expect($result['24h'])->toBe(100.0);
+});
+
+// ─── Caching ──────────────────────────────────────────────────────────────────
+
+test('result is cached for 5 minutes', function () {
+    $monitor = Monitor::factory()->create(['user_id' => User::factory()]);
+    createChecks($monitor, successful: 10, failed: 0, age: '2 hours');
+
+    // First call populates cache
+    $first = $monitor->uptimePercentage('24h');
+    expect($first)->toBe(100.0);
+
+    // Add a failed check — cached value should not change
+    CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 500,
+        'response_time_ms' => 0,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    expect($monitor->uptimePercentage('24h'))->toBe(100.0);
+
+    // After clearing cache, value should update
+    Cache::forget("monitor:{$monitor->id}:uptime:24h");
+    expect($monitor->uptimePercentage('24h'))->not->toBe(100.0);
+});
+
+// ─── Dashboard endpoint ──────────────────────────────────────────────────────
+
+test('dashboard includes uptime_24h for each monitor', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+    createChecks($monitor, successful: 9, failed: 1, age: '2 hours');
+
+    $response = $this->actingAs($user)->get(route('dashboard'));
+
+    $response->assertOk();
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors[0]['uptime_24h'])->toBe(90.0);
+});
+
+// ─── Show endpoint ───────────────────────────────────────────────────────────
+
+test('show page includes all uptime periods', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+    createChecks($monitor, successful: 10, failed: 0, age: '2 hours');
+
+    $response = $this->actingAs($user)->get(route('monitors.show', $monitor));
+
+    $response->assertOk();
+    $uptime = $response->original->getData()['page']['props']['uptime'];
+    expect($uptime)->toHaveKeys(['24h', '7d', '30d']);
+    expect($uptime['24h'])->toBe(100.0);
+});


### PR DESCRIPTION
- Added `uptimePercentage` method to the `Monitor` model to calculate uptime over specified time ranges (24h, 7d, 30d) with caching.
- Updated `MonitorController` to include uptime data in the dashboard and show views.
- Enhanced the `Dashboard.vue` and `Show.vue` components to display uptime information visually.
- Created a new `UptimeCalculationTest` to validate uptime calculations and ensure correct functionality.
- Modified local settings to include new test commands for uptime-related tests.