### PR TITLE
US-6.2 · Selezione Monitor per Status Page #27

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,9 @@
       "Bash(npm install:*)",
       "Bash(./vendor/bin/pest tests/Feature/MonitorMetricsTest.php --no-coverage)",
       "Bash(./vendor/bin/pest tests/Feature/UptimeCalculationTest.php --no-coverage)",
-      "Bash(./vendor/bin/pest tests/Feature/StatusPageCrudTest.php --no-coverage)"
+      "Bash(./vendor/bin/pest tests/Feature/StatusPageCrudTest.php --no-coverage)",
+      "Bash(./vendor/bin/pest tests/Feature/StatusPageMonitorsTest.php)",
+      "Bash(./vendor/bin/pest)"
     ]
   }
 }

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -8,6 +8,7 @@ use App\Models\StatusPage;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -83,9 +84,83 @@ class StatusPageController extends Controller
     {
         Gate::authorize('update', $statusPage);
 
-        $statusPage->update(['is_active' => ! $statusPage->is_active]);
+        $wantsActive = ! $statusPage->is_active;
+
+        if ($wantsActive && $statusPage->monitors()->count() === 0) {
+            return back()->withErrors(['monitors' => 'Aggiungi almeno un monitor prima di attivare la status page.']);
+        }
+
+        $statusPage->update(['is_active' => $wantsActive]);
 
         return back()->with('message', $statusPage->is_active ? 'Status page attivata.' : 'Status page disattivata.');
+    }
+
+    public function configure(Request $request, StatusPage $statusPage): Response
+    {
+        Gate::authorize('update', $statusPage);
+
+        $userMonitors = $request->user()
+            ->monitors()
+            ->orderBy('name')
+            ->get(['id', 'name', 'url']);
+
+        $attached = $statusPage->monitors()
+            ->get()
+            ->map(fn ($m) => [
+                'monitor_id'   => $m->id,
+                'display_name' => $m->pivot->display_name,
+                'sort_order'   => $m->pivot->sort_order,
+            ]);
+
+        return Inertia::render('StatusPages/Configure', [
+            'statusPage'   => [
+                'id'    => $statusPage->id,
+                'title' => $statusPage->title,
+            ],
+            'userMonitors' => $userMonitors,
+            'attached'     => $attached,
+        ]);
+    }
+
+    public function updateMonitors(Request $request, StatusPage $statusPage): RedirectResponse
+    {
+        Gate::authorize('update', $statusPage);
+
+        $validated = $request->validate([
+            'monitors'                => ['present', 'array'],
+            'monitors.*.monitor_id'   => ['required', 'integer', 'exists:monitors,id'],
+            'monitors.*.display_name' => ['nullable', 'string', 'max:255'],
+            'monitors.*.sort_order'   => ['required', 'integer', 'min:0'],
+        ]);
+
+        // Verify all monitors belong to the user
+        $userMonitorIds = $request->user()->monitors()->pluck('id')->toArray();
+        $requestedIds   = collect($validated['monitors'])->pluck('monitor_id')->toArray();
+
+        if (array_diff($requestedIds, $userMonitorIds)) {
+            abort(403, 'Cannot attach monitors you do not own.');
+        }
+
+        // If page is active, require at least 1 monitor
+        if ($statusPage->is_active && empty($validated['monitors'])) {
+            throw ValidationException::withMessages([
+                'monitors' => 'Una status page attiva deve avere almeno un monitor.',
+            ]);
+        }
+
+        // Sync pivot
+        $syncData = [];
+        foreach ($validated['monitors'] as $entry) {
+            $syncData[$entry['monitor_id']] = [
+                'display_name' => $entry['display_name'],
+                'sort_order'   => $entry['sort_order'],
+            ];
+        }
+
+        $statusPage->monitors()->sync($syncData);
+
+        return redirect()->route('status-pages.configure', $statusPage)
+            ->with('message', 'Monitor aggiornati con successo.');
     }
 
     public function publicShow(StatusPage $statusPage): Response
@@ -94,13 +169,12 @@ class StatusPageController extends Controller
             abort(404);
         }
 
-        $monitors = $statusPage->user->monitors()
+        $monitors = $statusPage->monitors()
             ->where('is_paused', false)
             ->with('latestCheckResult')
-            ->orderBy('name')
             ->get()
             ->map(fn ($m) => [
-                'name'           => $m->name ?? $m->url,
+                'name'           => $m->pivot->display_name ?? $m->name ?? $m->url,
                 'current_status' => $m->current_status,
                 'response_time'  => $m->latestCheckResult?->response_time_ms,
             ]);

--- a/app/Models/StatusPage.php
+++ b/app/Models/StatusPage.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class StatusPage extends Model
 {
@@ -28,5 +29,12 @@ class StatusPage extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function monitors(): BelongsToMany
+    {
+        return $this->belongsToMany(Monitor::class)
+            ->withPivot('display_name', 'sort_order')
+            ->orderByPivot('sort_order');
     }
 }

--- a/database/migrations/2026_04_16_000002_create_monitor_status_page_table.php
+++ b/database/migrations/2026_04_16_000002_create_monitor_status_page_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('monitor_status_page', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('monitor_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('status_page_id')->constrained()->cascadeOnDelete();
+            $table->string('display_name')->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+
+            $table->unique(['monitor_id', 'status_page_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monitor_status_page');
+    }
+};

--- a/resources/js/Pages/StatusPages/Configure.vue
+++ b/resources/js/Pages/StatusPages/Configure.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import { Head, useForm, usePage } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+interface UserMonitor {
+    id: number;
+    name: string | null;
+    url: string;
+}
+
+interface AttachedEntry {
+    monitor_id: number;
+    display_name: string | null;
+    sort_order: number;
+}
+
+const props = defineProps<{
+    statusPage: { id: number; title: string };
+    userMonitors: UserMonitor[];
+    attached: AttachedEntry[];
+}>();
+
+const flash = computed(() => usePage().props.flash as { message?: string });
+
+// Build initial selected state from attached
+const selected = ref<Map<number, { display_name: string; sort_order: number }>>(
+    new Map(props.attached.map(a => [a.monitor_id, {
+        display_name: a.display_name ?? '',
+        sort_order: a.sort_order,
+    }]))
+);
+
+function isChecked(monitorId: number): boolean {
+    return selected.value.has(monitorId);
+}
+
+function toggleMonitor(monitorId: number) {
+    if (selected.value.has(monitorId)) {
+        selected.value.delete(monitorId);
+    } else {
+        selected.value.set(monitorId, {
+            display_name: '',
+            sort_order: selected.value.size,
+        });
+    }
+}
+
+function getEntry(monitorId: number) {
+    return selected.value.get(monitorId)!;
+}
+
+function moveUp(monitorId: number) {
+    const entry = selected.value.get(monitorId);
+    if (!entry || entry.sort_order <= 0) return;
+
+    for (const [id, e] of selected.value) {
+        if (e.sort_order === entry.sort_order - 1) {
+            e.sort_order++;
+            break;
+        }
+    }
+    entry.sort_order--;
+}
+
+function moveDown(monitorId: number) {
+    const entry = selected.value.get(monitorId);
+    if (!entry || entry.sort_order >= selected.value.size - 1) return;
+
+    for (const [id, e] of selected.value) {
+        if (e.sort_order === entry.sort_order + 1) {
+            e.sort_order--;
+            break;
+        }
+    }
+    entry.sort_order++;
+}
+
+const sortedSelected = computed(() => {
+    return props.userMonitors
+        .filter(m => selected.value.has(m.id))
+        .sort((a, b) => (selected.value.get(a.id)!.sort_order) - (selected.value.get(b.id)!.sort_order));
+});
+
+const form = useForm<{ monitors: AttachedEntry[] }>({ monitors: [] });
+
+function submit() {
+    form.monitors = Array.from(selected.value.entries()).map(([id, entry]) => ({
+        monitor_id: id,
+        display_name: entry.display_name || null,
+        sort_order: entry.sort_order,
+    }));
+    form.put(route('status-pages.update-monitors', props.statusPage.id));
+}
+</script>
+
+<template>
+    <Head :title="`Configura ${statusPage.title}`" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <div class="flex items-center gap-3">
+                <a
+                    :href="route('status-pages.index')"
+                    class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                    ← Status Pages
+                </a>
+                <span class="text-gray-300 dark:text-gray-600">/</span>
+                <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200">
+                    Configura "{{ statusPage.title }}"
+                </h2>
+            </div>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-3xl sm:px-6 lg:px-8 space-y-6">
+
+                <!-- Flash -->
+                <Transition
+                    enter-active-class="transition ease-in-out duration-300"
+                    enter-from-class="opacity-0 -translate-y-1"
+                    leave-active-class="transition ease-in-out duration-300"
+                    leave-to-class="opacity-0 -translate-y-1"
+                >
+                    <div
+                        v-if="flash.message"
+                        class="rounded-lg bg-green-50 px-4 py-3 text-sm text-green-700 shadow-sm dark:bg-green-900/30 dark:text-green-300"
+                    >
+                        {{ flash.message }}
+                    </div>
+                </Transition>
+
+                <form @submit.prevent="submit" class="space-y-6">
+                    <!-- Monitor selection -->
+                    <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800 p-6">
+                        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+                            Seleziona monitor
+                        </h3>
+
+                        <div v-if="userMonitors.length === 0" class="text-sm text-gray-500 dark:text-gray-400">
+                            Nessun monitor disponibile. Crea prima un monitor.
+                        </div>
+
+                        <div v-else class="space-y-2">
+                            <label
+                                v-for="monitor in userMonitors"
+                                :key="monitor.id"
+                                class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/40 cursor-pointer"
+                            >
+                                <input
+                                    type="checkbox"
+                                    :checked="isChecked(monitor.id)"
+                                    @change="toggleMonitor(monitor.id)"
+                                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900"
+                                />
+                                <div class="min-w-0">
+                                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                        {{ monitor.name ?? '—' }}
+                                    </span>
+                                    <span class="ml-2 text-xs text-gray-400 dark:text-gray-500 truncate">
+                                        {{ monitor.url }}
+                                    </span>
+                                </div>
+                            </label>
+                        </div>
+
+                        <InputError class="mt-2" :message="form.errors.monitors" />
+                    </div>
+
+                    <!-- Order & display name -->
+                    <div
+                        v-if="sortedSelected.length > 0"
+                        class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800 p-6"
+                    >
+                        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+                            Ordine e nome visualizzato
+                        </h3>
+
+                        <div class="space-y-3">
+                            <div
+                                v-for="(monitor, idx) in sortedSelected"
+                                :key="monitor.id"
+                                class="flex items-center gap-3 rounded-md border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/60"
+                            >
+                                <!-- Order controls -->
+                                <div class="flex flex-col gap-0.5">
+                                    <button
+                                        type="button"
+                                        @click="moveUp(monitor.id)"
+                                        :disabled="idx === 0"
+                                        class="text-gray-400 hover:text-gray-600 disabled:opacity-25 dark:hover:text-gray-300"
+                                    >
+                                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+                                        </svg>
+                                    </button>
+                                    <button
+                                        type="button"
+                                        @click="moveDown(monitor.id)"
+                                        :disabled="idx === sortedSelected.length - 1"
+                                        class="text-gray-400 hover:text-gray-600 disabled:opacity-25 dark:hover:text-gray-300"
+                                    >
+                                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                                        </svg>
+                                    </button>
+                                </div>
+
+                                <!-- Monitor info -->
+                                <div class="flex-1 min-w-0">
+                                    <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
+                                        {{ monitor.name ?? monitor.url }}
+                                    </p>
+                                    <input
+                                        type="text"
+                                        v-model="getEntry(monitor.id).display_name"
+                                        :placeholder="monitor.name ?? monitor.url"
+                                        class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Submit -->
+                    <div class="flex justify-end">
+                        <PrimaryButton
+                            :class="{ 'opacity-25': form.processing }"
+                            :disabled="form.processing"
+                        >
+                            Salva configurazione
+                        </PrimaryButton>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/StatusPages/Index.vue
+++ b/resources/js/Pages/StatusPages/Index.vue
@@ -144,6 +144,12 @@ function toggleActive(sp: StatusPage) {
                                     {{ sp.is_active ? 'Disattiva' : 'Attiva' }}
                                 </button>
                                 <Link
+                                    :href="route('status-pages.configure', sp.id)"
+                                    class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                                >
+                                    Configura
+                                </Link>
+                                <Link
                                     :href="route('status-pages.edit', sp.id)"
                                     class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                                 >

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/status-pages/{status_page}/edit', [StatusPageController::class, 'edit'])->name('status-pages.edit');
     Route::put('/status-pages/{status_page}', [StatusPageController::class, 'update'])->name('status-pages.update');
     Route::patch('/status-pages/{status_page}/toggle', [StatusPageController::class, 'toggle'])->name('status-pages.toggle');
+    Route::get('/status-pages/{status_page}/configure', [StatusPageController::class, 'configure'])->name('status-pages.configure');
+    Route::put('/status-pages/{status_page}/monitors', [StatusPageController::class, 'updateMonitors'])->name('status-pages.update-monitors');
     Route::delete('/status-pages/{status_page}', [StatusPageController::class, 'destroy'])->name('status-pages.destroy');
 });
 

--- a/tests/Feature/StatusPageCrudTest.php
+++ b/tests/Feature/StatusPageCrudTest.php
@@ -183,6 +183,8 @@ test('slug uniqueness allows keeping the same slug on update', function () {
 test('owner can toggle active state', function () {
     $user = User::factory()->create();
     $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+    $mon  = Monitor::factory()->create(['user_id' => $user->id]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
 
     $this->actingAs($user)
         ->patch(route('status-pages.toggle', $sp))
@@ -229,12 +231,13 @@ test('active status page is publicly accessible by slug', function () {
         'slug'      => 'acme-status',
         'is_active' => true,
     ]);
-    Monitor::factory()->create([
+    $mon = Monitor::factory()->create([
         'user_id'        => $user->id,
         'name'           => 'API',
         'current_status' => 'up',
         'is_paused'      => false,
     ]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
 
     $this->get('/status/acme-status')
         ->assertOk()

--- a/tests/Feature/StatusPageMonitorsTest.php
+++ b/tests/Feature/StatusPageMonitorsTest.php
@@ -1,0 +1,289 @@
+<?php
+
+use App\Models\Monitor;
+use App\Models\StatusPage;
+use App\Models\User;
+
+// ─── Configure page ──────────────────────────────────────────────────────────
+
+test('owner can view the configure page', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->get(route('status-pages.configure', $sp))
+        ->assertOk();
+});
+
+test('non-owner cannot view configure page', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $sp    = StatusPage::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($other)
+        ->get(route('status-pages.configure', $sp))
+        ->assertForbidden();
+});
+
+test('configure page lists user monitors', function () {
+    $user    = User::factory()->create();
+    $sp      = StatusPage::factory()->create(['user_id' => $user->id]);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'name' => 'My API']);
+
+    $response = $this->actingAs($user)
+        ->get(route('status-pages.configure', $sp));
+
+    $response->assertOk();
+    $userMonitors = $response->original->getData()['page']['props']['userMonitors'];
+    expect($userMonitors)->toHaveCount(1);
+    expect($userMonitors[0]['name'])->toBe('My API');
+});
+
+test('configure page shows already attached monitors', function () {
+    $user    = User::factory()->create();
+    $sp      = StatusPage::factory()->create(['user_id' => $user->id]);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $sp->monitors()->attach($monitor->id, ['display_name' => 'Custom Name', 'sort_order' => 0]);
+
+    $response = $this->actingAs($user)
+        ->get(route('status-pages.configure', $sp));
+
+    $attached = $response->original->getData()['page']['props']['attached'];
+    expect($attached)->toHaveCount(1);
+    expect($attached[0]['display_name'])->toBe('Custom Name');
+});
+
+// ─── Update monitors (sync pivot) ───────────────────────────────────────────
+
+test('owner can attach monitors to status page', function () {
+    $user    = User::factory()->create();
+    $sp      = StatusPage::factory()->create(['user_id' => $user->id]);
+    $mon1    = Monitor::factory()->create(['user_id' => $user->id]);
+    $mon2    = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->put(route('status-pages.update-monitors', $sp), [
+            'monitors' => [
+                ['monitor_id' => $mon1->id, 'display_name' => 'API', 'sort_order' => 0],
+                ['monitor_id' => $mon2->id, 'display_name' => null,  'sort_order' => 1],
+            ],
+        ])
+        ->assertRedirect(route('status-pages.configure', $sp));
+
+    expect($sp->monitors()->count())->toBe(2);
+
+    $this->assertDatabaseHas('monitor_status_page', [
+        'monitor_id'     => $mon1->id,
+        'status_page_id' => $sp->id,
+        'display_name'   => 'API',
+        'sort_order'     => 0,
+    ]);
+});
+
+test('sync removes monitors not in the request', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+    $mon1 = Monitor::factory()->create(['user_id' => $user->id]);
+    $mon2 = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $sp->monitors()->attach([
+        $mon1->id => ['sort_order' => 0],
+        $mon2->id => ['sort_order' => 1],
+    ]);
+
+    // Keep only mon2
+    $this->actingAs($user)
+        ->put(route('status-pages.update-monitors', $sp), [
+            'monitors' => [
+                ['monitor_id' => $mon2->id, 'display_name' => null, 'sort_order' => 0],
+            ],
+        ])
+        ->assertRedirect();
+
+    expect($sp->monitors()->count())->toBe(1);
+    $this->assertDatabaseMissing('monitor_status_page', [
+        'monitor_id'     => $mon1->id,
+        'status_page_id' => $sp->id,
+    ]);
+});
+
+test('non-owner cannot update monitors', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $sp    = StatusPage::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($other)
+        ->put(route('status-pages.update-monitors', $sp), ['monitors' => []])
+        ->assertForbidden();
+});
+
+// ─── Ownership validation ────────────────────────────────────────────────────
+
+test('cannot attach monitors owned by another user', function () {
+    $user      = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $sp        = StatusPage::factory()->create(['user_id' => $user->id]);
+    $otherMon  = Monitor::factory()->create(['user_id' => $otherUser->id]);
+
+    $this->actingAs($user)
+        ->put(route('status-pages.update-monitors', $sp), [
+            'monitors' => [
+                ['monitor_id' => $otherMon->id, 'display_name' => null, 'sort_order' => 0],
+            ],
+        ])
+        ->assertForbidden();
+});
+
+// ─── Activation guard ────────────────────────────────────────────────────────
+
+test('cannot remove all monitors from an active status page', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+    $mon  = Monitor::factory()->create(['user_id' => $user->id]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
+
+    $this->actingAs($user)
+        ->put(route('status-pages.update-monitors', $sp), [
+            'monitors' => [],
+        ])
+        ->assertSessionHasErrors('monitors');
+
+    // Monitor should still be attached
+    expect($sp->monitors()->count())->toBe(1);
+});
+
+test('can remove all monitors from an inactive status page', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+    $mon  = Monitor::factory()->create(['user_id' => $user->id]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
+
+    $this->actingAs($user)
+        ->put(route('status-pages.update-monitors', $sp), [
+            'monitors' => [],
+        ])
+        ->assertRedirect();
+
+    expect($sp->monitors()->count())->toBe(0);
+});
+
+test('cannot activate a status page with no monitors', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+
+    $this->actingAs($user)
+        ->patch(route('status-pages.toggle', $sp))
+        ->assertRedirect();
+
+    expect($sp->fresh()->is_active)->toBeFalse();
+});
+
+test('can activate a status page that has monitors', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+    $mon  = Monitor::factory()->create(['user_id' => $user->id]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
+
+    $this->actingAs($user)
+        ->patch(route('status-pages.toggle', $sp))
+        ->assertRedirect();
+
+    expect($sp->fresh()->is_active)->toBeTrue();
+});
+
+// ─── Display name on public page ─────────────────────────────────────────────
+
+test('public page shows pivot display_name when set', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create([
+        'user_id'   => $user->id,
+        'is_active' => true,
+    ]);
+    $mon = Monitor::factory()->create([
+        'user_id'        => $user->id,
+        'name'           => 'Original Name',
+        'current_status' => 'up',
+        'is_paused'      => false,
+    ]);
+    $sp->monitors()->attach($mon->id, ['display_name' => 'Custom Public Name', 'sort_order' => 0]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $response->assertOk();
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors[0]['name'])->toBe('Custom Public Name');
+});
+
+test('public page falls back to monitor name when display_name is null', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create([
+        'user_id'   => $user->id,
+        'is_active' => true,
+    ]);
+    $mon = Monitor::factory()->create([
+        'user_id'        => $user->id,
+        'name'           => 'My API',
+        'current_status' => 'up',
+        'is_paused'      => false,
+    ]);
+    $sp->monitors()->attach($mon->id, ['display_name' => null, 'sort_order' => 0]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors[0]['name'])->toBe('My API');
+});
+
+// ─── Sort order ──────────────────────────────────────────────────────────────
+
+test('public page respects sort_order from pivot', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create([
+        'user_id'   => $user->id,
+        'is_active' => true,
+    ]);
+    $monA = Monitor::factory()->create([
+        'user_id' => $user->id, 'name' => 'Alpha', 'current_status' => 'up', 'is_paused' => false,
+    ]);
+    $monB = Monitor::factory()->create([
+        'user_id' => $user->id, 'name' => 'Beta', 'current_status' => 'up', 'is_paused' => false,
+    ]);
+
+    // Beta first (sort_order 0), Alpha second (sort_order 1)
+    $sp->monitors()->attach([
+        $monB->id => ['sort_order' => 0],
+        $monA->id => ['sort_order' => 1],
+    ]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors[0]['name'])->toBe('Beta');
+    expect($monitors[1]['name'])->toBe('Alpha');
+});
+
+test('paused monitors are excluded from public page', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create([
+        'user_id'   => $user->id,
+        'is_active' => true,
+    ]);
+    $active = Monitor::factory()->create([
+        'user_id' => $user->id, 'name' => 'Active', 'current_status' => 'up', 'is_paused' => false,
+    ]);
+    $paused = Monitor::factory()->create([
+        'user_id' => $user->id, 'name' => 'Paused', 'current_status' => 'up', 'is_paused' => true,
+    ]);
+
+    $sp->monitors()->attach([
+        $active->id => ['sort_order' => 0],
+        $paused->id => ['sort_order' => 1],
+    ]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors)->toHaveCount(1);
+    expect($monitors[0]['name'])->toBe('Active');
+});


### PR DESCRIPTION
- Added a new `configure` method in `StatusPageController` to manage monitor associations with status pages.
- Introduced a Vue component for configuring monitors, allowing users to select and order monitors for their status pages.
- Updated the `StatusPage` model to include a many-to-many relationship with monitors.
- Created a migration for the pivot table `monitor_status_page` to store monitor associations.
- Enhanced existing tests to cover the new configuration functionality and ensure proper access control.
- Updated routes to include new endpoints for configuring and updating monitors associated with status pages.