### PR TITLE
 US-6.3 · Pagina Pubblica con Uptime History #28

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(./vendor/bin/pest tests/Feature/UptimeCalculationTest.php --no-coverage)",
       "Bash(./vendor/bin/pest tests/Feature/StatusPageCrudTest.php --no-coverage)",
       "Bash(./vendor/bin/pest tests/Feature/StatusPageMonitorsTest.php)",
-      "Bash(./vendor/bin/pest)"
+      "Bash(./vendor/bin/pest)",
+      "Bash(./vendor/bin/pest tests/Feature/PublicStatusPageTest.php)"
     ]
   }
 }

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -177,6 +177,7 @@ class StatusPageController extends Controller
                 'name'           => $m->pivot->display_name ?? $m->name ?? $m->url,
                 'current_status' => $m->current_status,
                 'response_time'  => $m->latestCheckResult?->response_time_ms,
+                'daily_uptime'   => $m->dailyUptime(90),
             ]);
 
         return Inertia::render('StatusPages/PublicShow', [

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -80,4 +80,40 @@ class Monitor extends Model
             '30d' => $this->uptimePercentage('30d'),
         ];
     }
+
+    /**
+     * Return daily uptime percentages for the last N days.
+     *
+     * @return array<string, float|null> date (Y-m-d) => percentage
+     */
+    public function dailyUptime(int $days = 90): array
+    {
+        $cacheKey = "monitor:{$this->id}:daily_uptime:{$days}";
+
+        return Cache::remember($cacheKey, 300, function () use ($days) {
+            $since = now()->subDays($days)->startOfDay();
+
+            $rows = $this->checkResults()
+                ->where('checked_at', '>=', $since)
+                ->selectRaw('DATE(checked_at) as day')
+                ->selectRaw('COUNT(*) as total')
+                ->selectRaw('SUM(CASE WHEN is_successful THEN 1 ELSE 0 END) as successful')
+                ->groupByRaw('DATE(checked_at)')
+                ->get()
+                ->keyBy('day');
+
+            $result = [];
+            for ($i = $days - 1; $i >= 0; $i--) {
+                $date = now()->subDays($i)->format('Y-m-d');
+                if ($rows->has($date)) {
+                    $row = $rows[$date];
+                    $result[$date] = round(($row->successful / $row->total) * 100, 2);
+                } else {
+                    $result[$date] = null;
+                }
+            }
+
+            return $result;
+        });
+    }
 }

--- a/database/seeders/StatusPageDemoSeeder.php
+++ b/database/seeders/StatusPageDemoSeeder.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\StatusPage;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+class StatusPageDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        // Create monitors
+        $api = Monitor::factory()->for($user)->create([
+            'name'           => 'API Backend',
+            'url'            => 'https://api.example.com/health',
+        ]);
+
+        $web = Monitor::factory()->create([
+            'user_id'        => $user->id,
+            'name'           => 'Website',
+            'url'            => 'https://www.example.com',
+            'current_status' => 'up',
+            'is_paused'      => false,
+        ]);
+
+        $db = Monitor::factory()->create([
+            'user_id'        => $user->id,
+            'name'           => 'Database',
+            'url'            => 'https://db.example.com/ping',
+            'current_status' => 'down',
+            'is_paused'      => false,
+        ]);
+
+        // Create status page
+        $sp = StatusPage::create([
+            'user_id'     => $user->id,
+            'title'       => 'Acme Services',
+            'slug'        => 'acme-demo',
+            'description' => 'Current status of Acme platform services.',
+            'is_active'   => true,
+        ]);
+
+        $sp->monitors()->attach([
+            $api->id => ['display_name' => 'API',      'sort_order' => 0],
+            $web->id => ['display_name' => 'Website',   'sort_order' => 1],
+            $db->id  => ['display_name' => 'Database',  'sort_order' => 2],
+        ]);
+
+        // Generate 90 days of check results
+        $this->command->info('Generating 90 days of check results...');
+
+        foreach ([$api, $web, $db] as $monitor) {
+            $this->seedCheckResults($monitor);
+        }
+
+        $this->command->info("Status page ready at: /status/acme-demo");
+    }
+
+    private function seedCheckResults(Monitor $monitor): void
+    {
+        $records = [];
+        $now = now();
+
+        for ($day = 89; $day >= 0; $day--) {
+            $date = $now->copy()->subDays($day)->startOfDay();
+            // ~24 checks per day (one per hour)
+            $checksPerDay = 24;
+
+            // Simulate realistic patterns:
+            // - Most days 100% uptime
+            // - A few days with partial failures
+            // - Rare full outage day
+            $failRate = $this->failRateForDay($monitor->name, $day);
+
+            for ($h = 0; $h < $checksPerDay; $h++) {
+                $checkedAt = $date->copy()->addHours($h)->addMinutes(rand(0, 4));
+                $isFail = (rand(1, 100) <= $failRate);
+
+                $records[] = [
+                    'monitor_id'       => $monitor->id,
+                    'status_code'      => $isFail ? (rand(0, 1) ? 500 : 503) : 200,
+                    'response_time_ms' => $isFail ? rand(5000, 30000) : rand(50, 400),
+                    'is_successful'    => ! $isFail,
+                    'checked_at'       => $checkedAt,
+                    'created_at'       => $checkedAt,
+                    'updated_at'       => $checkedAt,
+                ];
+            }
+        }
+
+        // Bulk insert in chunks
+        foreach (array_chunk($records, 500) as $chunk) {
+            CheckResult::insert($chunk);
+        }
+
+        $this->command->info("  {$monitor->name}: " . count($records) . ' check results');
+    }
+
+    private function failRateForDay(string $monitorName, int $daysAgo): int
+    {
+        // "Database" monitor: more incidents
+        if ($monitorName === 'Database') {
+            if ($daysAgo === 3) return 100;  // full outage 3 days ago
+            if ($daysAgo === 15) return 40;
+            if ($daysAgo === 30) return 20;
+            if ($daysAgo === 60) return 60;
+            if ($daysAgo === 0) return 30;   // currently degraded
+            return rand(0, 100) <= 5 ? 8 : 0;
+        }
+
+        // "Website": occasional issues
+        if ($monitorName === 'Website') {
+            if ($daysAgo === 10) return 15;
+            if ($daysAgo === 45) return 25;
+            return 0;
+        }
+
+        // "API Backend": very stable
+        if ($daysAgo === 20) return 5;
+        return 0;
+    }
+}

--- a/resources/js/Pages/StatusPages/PublicShow.vue
+++ b/resources/js/Pages/StatusPages/PublicShow.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+interface DailyUptime {
+    [date: string]: number | null;
+}
 
 interface Monitor {
     name: string;
     current_status: 'unknown' | 'up' | 'down';
     response_time: number | null;
+    daily_uptime: DailyUptime;
 }
 
 const props = defineProps<{
@@ -15,90 +21,223 @@ const props = defineProps<{
     monitors: Monitor[];
 }>();
 
-const statusConfig: Record<string, { label: string; dot: string; bg: string }> = {
-    up:      { label: 'Operativo',    dot: 'bg-green-500', bg: 'bg-green-50 dark:bg-green-900/20' },
-    down:    { label: 'Non operativo', dot: 'bg-red-500',   bg: 'bg-red-50 dark:bg-red-900/20' },
-    unknown: { label: 'Sconosciuto',  dot: 'bg-gray-400',  bg: 'bg-gray-50 dark:bg-gray-800' },
+// ─── Status helpers ──────────────────────────────────────────────────────────
+
+function statusLabel(status: string): string {
+    return { up: 'Operational', down: 'Down', unknown: 'Unknown' }[status] ?? 'Unknown';
+}
+
+function statusDotClass(status: string): string {
+    return {
+        up: 'bg-green-500',
+        down: 'bg-red-500',
+        unknown: 'bg-gray-400',
+    }[status] ?? 'bg-gray-400';
+}
+
+function statusTextClass(status: string): string {
+    return {
+        up: 'text-green-600 dark:text-green-400',
+        down: 'text-red-600 dark:text-red-400',
+        unknown: 'text-gray-400 dark:text-gray-500',
+    }[status] ?? 'text-gray-400';
+}
+
+// ─── Overall status ──────────────────────────────────────────────────────────
+
+const overallStatus = computed(() => {
+    if (props.monitors.length === 0) return 'empty';
+    const hasDown = props.monitors.some(m => m.current_status === 'down');
+    const allUp = props.monitors.every(m => m.current_status === 'up');
+    if (allUp) return 'operational';
+    if (hasDown) return 'major';
+    return 'partial';
+});
+
+const overallConfig = {
+    operational: {
+        label: 'All Systems Operational',
+        icon: '✓',
+        bg: 'bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-800',
+        text: 'text-green-800 dark:text-green-300',
+        iconBg: 'bg-green-500',
+    },
+    partial: {
+        label: 'Partial Outage',
+        icon: '!',
+        bg: 'bg-yellow-50 border-yellow-200 dark:bg-yellow-900/20 dark:border-yellow-800',
+        text: 'text-yellow-800 dark:text-yellow-300',
+        iconBg: 'bg-yellow-500',
+    },
+    major: {
+        label: 'Major Outage',
+        icon: '!',
+        bg: 'bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-800',
+        text: 'text-red-800 dark:text-red-300',
+        iconBg: 'bg-red-500',
+    },
+    empty: {
+        label: 'No services monitored',
+        icon: '?',
+        bg: 'bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-700',
+        text: 'text-gray-600 dark:text-gray-400',
+        iconBg: 'bg-gray-400',
+    },
 };
 
-const allUp = props.monitors.length > 0 && props.monitors.every(m => m.current_status === 'up');
-const someDown = props.monitors.some(m => m.current_status === 'down');
+// ─── Uptime bar helpers ──────────────────────────────────────────────────────
+
+function dayColor(uptime: number | null): string {
+    if (uptime === null) return 'bg-gray-200 dark:bg-gray-700';
+    if (uptime === 100) return 'bg-green-500';
+    if (uptime >= 95) return 'bg-yellow-400';
+    return 'bg-red-500';
+}
+
+function formatDate(dateStr: string): string {
+    const d = new Date(dateStr + 'T00:00:00');
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function uptimeLabel(uptime: number | null): string {
+    if (uptime === null) return 'No data';
+    return `${uptime}% uptime`;
+}
+
+function overallUptimePercent(dailyUptime: DailyUptime): string | null {
+    const values = Object.values(dailyUptime).filter((v): v is number => v !== null);
+    if (values.length === 0) return null;
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    return avg.toFixed(2);
+}
+
+// ─── Tooltip state ───────────────────────────────────────────────────────────
+
+const tooltip = ref<{ show: boolean; x: number; y: number; date: string; uptime: number | null }>({
+    show: false, x: 0, y: 0, date: '', uptime: null,
+});
+
+function showTooltip(event: MouseEvent, date: string, uptime: number | null) {
+    const rect = (event.target as HTMLElement).getBoundingClientRect();
+    tooltip.value = {
+        show: true,
+        x: rect.left + rect.width / 2,
+        y: rect.top - 8,
+        date,
+        uptime,
+    };
+}
+
+function hideTooltip() {
+    tooltip.value.show = false;
+}
 </script>
 
 <template>
     <Head :title="statusPage.title" />
 
+    <!-- Tooltip (portal to body-level) -->
+    <Teleport to="body">
+        <Transition
+            enter-active-class="transition duration-100 ease-out"
+            enter-from-class="opacity-0 translate-y-1"
+            leave-active-class="transition duration-75 ease-in"
+            leave-to-class="opacity-0 translate-y-1"
+        >
+            <div
+                v-if="tooltip.show"
+                class="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg dark:bg-gray-100 dark:text-gray-900"
+                :style="{ left: `${tooltip.x}px`, top: `${tooltip.y}px` }"
+            >
+                <p class="font-medium">{{ formatDate(tooltip.date) }}</p>
+                <p class="mt-0.5 opacity-80">{{ uptimeLabel(tooltip.uptime) }}</p>
+                <div class="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-100" />
+            </div>
+        </Transition>
+    </Teleport>
+
     <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
         <div class="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+
             <!-- Header -->
-            <div class="text-center mb-10">
-                <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            <div class="text-center mb-8">
+                <h1 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
                     {{ statusPage.title }}
                 </h1>
-                <p v-if="statusPage.description" class="mt-2 text-gray-500 dark:text-gray-400">
+                <p v-if="statusPage.description" class="mt-2 text-base text-gray-500 dark:text-gray-400">
                     {{ statusPage.description }}
                 </p>
             </div>
 
-            <!-- Global status banner -->
+            <!-- Overall status banner -->
             <div
-                class="mb-8 rounded-lg px-6 py-4 text-center text-sm font-medium"
-                :class="allUp
-                    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-                    : someDown
-                        ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
-                        : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'"
+                class="mb-8 flex items-center justify-center gap-3 rounded-xl border px-6 py-4"
+                :class="[overallConfig[overallStatus].bg]"
             >
-                <template v-if="monitors.length === 0">
-                    Nessun servizio monitorato.
-                </template>
-                <template v-else-if="allUp">
-                    Tutti i sistemi sono operativi.
-                </template>
-                <template v-else-if="someDown">
-                    Alcuni sistemi presentano problemi.
-                </template>
-                <template v-else>
-                    Stato dei servizi in aggiornamento.
-                </template>
+                <span
+                    class="flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold text-white"
+                    :class="overallConfig[overallStatus].iconBg"
+                >
+                    {{ overallConfig[overallStatus].icon }}
+                </span>
+                <span class="text-sm font-semibold" :class="overallConfig[overallStatus].text">
+                    {{ overallConfig[overallStatus].label }}
+                </span>
             </div>
 
             <!-- Monitor list -->
-            <div class="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-gray-900">
-                <div class="divide-y divide-gray-100 dark:divide-gray-800">
-                    <div
-                        v-for="(monitor, i) in monitors"
-                        :key="i"
-                        class="flex items-center justify-between px-6 py-4"
-                    >
-                        <div class="flex items-center gap-3">
-                            <span :class="['h-2.5 w-2.5 rounded-full', statusConfig[monitor.current_status].dot]" />
-                            <span class="font-medium text-gray-900 dark:text-gray-100">
+            <div class="space-y-4">
+                <div
+                    v-for="(monitor, i) in monitors"
+                    :key="i"
+                    class="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-800"
+                >
+                    <!-- Monitor header row -->
+                    <div class="flex items-center justify-between px-5 pt-4 pb-2">
+                        <div class="flex items-center gap-2.5">
+                            <span :class="['h-2.5 w-2.5 rounded-full', statusDotClass(monitor.current_status)]" />
+                            <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">
                                 {{ monitor.name }}
                             </span>
                         </div>
+                        <span class="text-xs font-medium" :class="statusTextClass(monitor.current_status)">
+                            {{ statusLabel(monitor.current_status) }}
+                        </span>
+                    </div>
 
-                        <div class="flex items-center gap-4">
-                            <span
-                                v-if="monitor.response_time !== null"
-                                class="text-xs text-gray-400 dark:text-gray-500"
-                            >
-                                {{ monitor.response_time }} ms
+                    <!-- 90-day uptime bar -->
+                    <div class="px-5 pb-4">
+                        <div class="flex items-end gap-px">
+                            <div
+                                v-for="(uptime, date) in monitor.daily_uptime"
+                                :key="date"
+                                :class="['flex-1 rounded-sm cursor-pointer transition-all hover:opacity-80', dayColor(uptime)]"
+                                style="min-width: 2px; height: 28px;"
+                                @mouseenter="showTooltip($event, date as string, uptime)"
+                                @mouseleave="hideTooltip"
+                            />
+                        </div>
+                        <div class="mt-1.5 flex items-center justify-between text-[10px] text-gray-400 dark:text-gray-500">
+                            <span>90 days ago</span>
+                            <span v-if="overallUptimePercent(monitor.daily_uptime)" class="font-medium">
+                                {{ overallUptimePercent(monitor.daily_uptime) }}% uptime
                             </span>
-                            <span class="text-xs font-medium" :class="{
-                                'text-green-600 dark:text-green-400': monitor.current_status === 'up',
-                                'text-red-600 dark:text-red-400': monitor.current_status === 'down',
-                                'text-gray-400': monitor.current_status === 'unknown',
-                            }">
-                                {{ statusConfig[monitor.current_status].label }}
-                            </span>
+                            <span>Today</span>
                         </div>
                     </div>
                 </div>
             </div>
 
+            <!-- Empty state -->
+            <div
+                v-if="monitors.length === 0"
+                class="mt-4 rounded-xl bg-white p-12 text-center shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-800"
+            >
+                <p class="text-sm text-gray-400 dark:text-gray-500">No services monitored.</p>
+            </div>
+
             <!-- Footer -->
-            <p class="mt-8 text-center text-xs text-gray-400 dark:text-gray-600">
+            <p class="mt-10 text-center text-xs text-gray-400 dark:text-gray-600">
                 Powered by WatchBoard
             </p>
         </div>

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\StatusPage;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+// ─── Daily uptime model method ──────────────────────────────────────────────
+
+test('dailyUptime returns 90 entries keyed by date', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $result = $monitor->dailyUptime(90);
+
+    expect($result)->toHaveCount(90);
+    expect(array_key_first($result))->toBe(now()->subDays(89)->format('Y-m-d'));
+    expect(array_key_last($result))->toBe(now()->format('Y-m-d'));
+});
+
+test('dailyUptime returns null for days with no checks', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $result = $monitor->dailyUptime(90);
+
+    // No checks created, all days should be null
+    foreach ($result as $uptime) {
+        expect($uptime)->toBeNull();
+    }
+});
+
+test('dailyUptime calculates percentage for a day with checks', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    // Today: 3 successful, 1 failed = 75%
+    $today = now()->format('Y-m-d');
+    for ($i = 0; $i < 3; $i++) {
+        CheckResult::factory()->create([
+            'monitor_id'    => $monitor->id,
+            'is_successful' => true,
+            'checked_at'    => now()->startOfDay()->addHours($i),
+        ]);
+    }
+    CheckResult::factory()->create([
+        'monitor_id'    => $monitor->id,
+        'is_successful' => false,
+        'checked_at'    => now()->startOfDay()->addHours(4),
+    ]);
+
+    $result = $monitor->dailyUptime(90);
+
+    expect($result[$today])->toBe(75.0);
+});
+
+test('dailyUptime returns 100 for a fully successful day', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    CheckResult::factory()->count(5)->create([
+        'monitor_id'    => $monitor->id,
+        'is_successful' => true,
+        'checked_at'    => now(),
+    ]);
+
+    $result = $monitor->dailyUptime(90);
+    $today = now()->format('Y-m-d');
+
+    expect($result[$today])->toBe(100.0);
+});
+
+test('dailyUptime is cached for 5 minutes', function () {
+    $user    = User::factory()->create();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    Cache::shouldReceive('remember')
+        ->once()
+        ->withArgs(fn ($key, $ttl) => $key === "monitor:{$monitor->id}:daily_uptime:90" && $ttl === 300)
+        ->andReturn([]);
+
+    $monitor->dailyUptime(90);
+});
+
+// ─── Public page response ────────────────────────────────────────────────────
+
+test('public page includes daily_uptime for each monitor', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+    $mon  = Monitor::factory()->create([
+        'user_id' => $user->id, 'current_status' => 'up', 'is_paused' => false,
+    ]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $response->assertOk();
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect($monitors[0])->toHaveKey('daily_uptime');
+    expect($monitors[0]['daily_uptime'])->toHaveCount(90);
+});
+
+test('public page daily_uptime reflects actual check data', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+    $mon  = Monitor::factory()->create([
+        'user_id' => $user->id, 'current_status' => 'up', 'is_paused' => false,
+    ]);
+    $sp->monitors()->attach($mon->id, ['sort_order' => 0]);
+
+    // Add checks for today
+    CheckResult::factory()->count(4)->create([
+        'monitor_id' => $mon->id, 'is_successful' => true, 'checked_at' => now(),
+    ]);
+    CheckResult::factory()->create([
+        'monitor_id' => $mon->id, 'is_successful' => false, 'checked_at' => now(),
+    ]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    $today    = now()->format('Y-m-d');
+    expect($monitors[0]['daily_uptime'][$today])->toBe(80.0);
+});
+
+test('overall status shows operational when all monitors are up', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+
+    $mon1 = Monitor::factory()->create(['user_id' => $user->id, 'current_status' => 'up', 'is_paused' => false]);
+    $mon2 = Monitor::factory()->create(['user_id' => $user->id, 'current_status' => 'up', 'is_paused' => false]);
+    $sp->monitors()->attach([$mon1->id => ['sort_order' => 0], $mon2->id => ['sort_order' => 1]]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    expect(collect($monitors)->every(fn ($m) => $m['current_status'] === 'up'))->toBeTrue();
+});
+
+test('overall status reflects down monitors', function () {
+    $user = User::factory()->create();
+    $sp   = StatusPage::factory()->create(['user_id' => $user->id, 'is_active' => true]);
+
+    $up   = Monitor::factory()->create(['user_id' => $user->id, 'current_status' => 'up', 'is_paused' => false]);
+    $down = Monitor::factory()->create(['user_id' => $user->id, 'current_status' => 'down', 'is_paused' => false]);
+    $sp->monitors()->attach([$up->id => ['sort_order' => 0], $down->id => ['sort_order' => 1]]);
+
+    $response = $this->get(route('status-pages.public', $sp->slug));
+
+    $monitors = $response->original->getData()['page']['props']['monitors'];
+    $statuses = collect($monitors)->pluck('current_status')->toArray();
+    expect($statuses)->toContain('down');
+    expect($statuses)->toContain('up');
+});
+
+test('inactive status page returns 404', function () {
+    $sp = StatusPage::factory()->create(['is_active' => false, 'slug' => 'hidden-page']);
+
+    $this->get('/status/hidden-page')->assertNotFound();
+});
+
+test('non-existent slug returns 404', function () {
+    $this->get('/status/no-such-page')->assertNotFound();
+});


### PR DESCRIPTION
- Implemented `dailyUptime` method in the `Monitor` model to calculate daily uptime percentages over the last 90 days, with caching for performance.
- Updated the `StatusPageController` to include daily uptime data in the public status page response.
- Enhanced the `PublicShow.vue` component to visually represent daily uptime for each monitor.
- Created a new `PublicStatusPageTest` to validate the daily uptime functionality and ensure accurate data display on the public status page.
- Added a new seeder, `StatusPageDemoSeeder`, to generate demo data for testing and development purposes.