### PR TITLE
US-9.1 · Deploy Produzione #32

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,19 @@
 name: Deploy
 
 # ─────────────────────────────────────────────────────────────────────────────
-# CD — Sprint 6 (US-9.1)
+# CD — pushes to master → deploy to production after CI green
 #
-# This workflow is intentionally disabled until the production infrastructure
-# is provisioned (VPS + Forge/Ploi or raw SSH access).
-#
-# Required GitHub Secrets (configure before enabling):
+# Required GitHub Secrets (Settings → Secrets → Actions):
 #   SSH_HOST          — Production server IP or hostname
-#   SSH_USER          — SSH user (e.g. forge, deploy)
-#   SSH_PRIVATE_KEY   — Private key for SSH authentication
+#   SSH_USER          — SSH user (e.g. deploy)
+#   SSH_PRIVATE_KEY   — Private key content for SSH authentication
 #   SSH_PORT          — SSH port (default: 22)
 #   DEPLOY_PATH       — Absolute path to the app on the server
-#                       e.g. /home/forge/watchboard.com
-#   SLACK_WEBHOOK_URL — (optional) Slack Incoming Webhook for deploy notifications
+#                       e.g. /var/www/watchboard
+#   SLACK_WEBHOOK_URL — (optional) Slack Incoming Webhook URL
 #
-# To enable: remove the `if: false` condition from the `deploy` job.
+# Optional GitHub Variables (Settings → Variables → Actions):
+#   SLACK_NOTIFY = 'true'   to enable Slack notifications
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
@@ -30,16 +28,15 @@ jobs:
   deploy:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    if: false   # ← remove this line in Sprint 6 when infra is ready
     environment:
       name: production
-      url: https://watchboard.app   # update with the real URL
+      url: https://watchboard.app
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Confirm CI passed on this commit before deploying
+      # Wait for the CI suite on this exact commit to go green
       - name: Wait for CI to succeed
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
@@ -51,10 +48,10 @@ jobs:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT }}
+          host:     ${{ secrets.SSH_HOST }}
+          port:     ${{ secrets.SSH_PORT }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          key:      ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e
             cd ${{ secrets.DEPLOY_PATH }}
@@ -62,13 +59,13 @@ jobs:
             echo "▶ Pulling latest code..."
             git pull origin master
 
-            echo "▶ Installing PHP dependencies..."
+            echo "▶ Installing PHP dependencies (production)..."
             composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 
-            echo "▶ Installing Node dependencies and building assets..."
+            echo "▶ Building frontend assets..."
             npm ci && npm run build
 
-            echo "▶ Running migrations..."
+            echo "▶ Running database migrations..."
             php artisan migrate --force
 
             echo "▶ Clearing and warming caches..."
@@ -77,19 +74,21 @@ jobs:
             php artisan view:cache
             php artisan event:cache
 
-            echo "▶ Restarting Horizon..."
+            echo "▶ Restarting Horizon (queue workers)..."
             php artisan horizon:terminate
 
-            echo "✅ Deploy completed."
+            echo "▶ Restarting Reverb (WebSocket server)..."
+            php artisan reverb:restart
 
-      # Optional Slack notification
+            echo "✅ Deploy completed successfully."
+
       - name: Notify Slack on success
         if: success() && vars.SLACK_NOTIFY == 'true'
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {
-              "text": "✅ *WatchBoard* deployed to production successfully.\nCommit: `${{ github.sha }}` by @${{ github.actor }}"
+              "text": "✅ *WatchBoard* deployed to production.\nCommit: `${{ github.sha }}` by @${{ github.actor }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -101,7 +100,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "🔴 *WatchBoard* deploy to production *FAILED*.\nCommit: `${{ github.sha }}` by @${{ github.actor }}\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "🔴 *WatchBoard* deploy FAILED.\nCommit: `${{ github.sha }}` by @${{ github.actor }}\nSee: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,17 +2,11 @@
 
 namespace App\Providers;
 
-use App\Events\MonitorStatusChanged;
-use App\Listeners\CloseIncident;
-use App\Listeners\OpenIncident;
-use App\Listeners\SendDownNotification;
-use App\Listeners\SendRecoveryNotification;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Vite;
@@ -34,11 +28,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Vite::prefetch(concurrency: 3);
-
-        Event::listen(MonitorStatusChanged::class, OpenIncident::class);
-        Event::listen(MonitorStatusChanged::class, CloseIncident::class);
-        Event::listen(MonitorStatusChanged::class, SendDownNotification::class);
-        Event::listen(MonitorStatusChanged::class, SendRecoveryNotification::class);
 
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,9 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
+    ->withEvents(discover: [
+        __DIR__.'/../app/Listeners',
+    ])
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -1,0 +1,71 @@
+# WatchBoard — Production Environment Template
+# Copy to /var/www/watchboard/.env and fill in every CHANGE_ME value.
+# Never commit the filled-in file.
+
+APP_NAME=WatchBoard
+APP_ENV=production
+APP_KEY=                              # php artisan key:generate --show
+APP_DEBUG=false
+APP_URL=https://watchboard.app
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+
+LOG_CHANNEL=daily
+LOG_LEVEL=warning
+
+# ── Database (PostgreSQL) ─────────────────────────────────────────────────────
+DB_CONNECTION=pgsql
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_DATABASE=watchboard
+DB_USERNAME=watchboard
+DB_PASSWORD=CHANGE_ME
+
+# ── Session & Cache ───────────────────────────────────────────────────────────
+SESSION_DRIVER=redis
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+
+CACHE_STORE=redis
+QUEUE_CONNECTION=redis
+BROADCAST_CONNECTION=reverb
+FILESYSTEM_DISK=local
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+# ── Mail (Resend — free tier, 3 000 emails/month) ────────────────────────────
+# Sign up at https://resend.com and create an API key
+MAIL_MAILER=smtp
+MAIL_HOST=smtp.resend.com
+MAIL_PORT=465
+MAIL_USERNAME=resend
+MAIL_PASSWORD=CHANGE_ME                # re_xxxxxxxxxxxx
+MAIL_ENCRYPTION=ssl
+MAIL_FROM_ADDRESS=noreply@watchboard.app
+MAIL_FROM_NAME="${APP_NAME}"
+
+# ── Reverb (WebSocket) — values from local .env or `php artisan reverb:install`
+# REVERB_PORT and REVERB_SCHEME must be 443 / https so the browser connects
+# to Nginx (which proxies to localhost:8080 internally).
+REVERB_APP_ID=CHANGE_ME
+REVERB_APP_KEY=CHANGE_ME
+REVERB_APP_SECRET=CHANGE_ME
+REVERB_HOST=watchboard.app
+REVERB_PORT=443
+REVERB_SCHEME=https
+
+VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+VITE_REVERB_HOST="${REVERB_HOST}"
+VITE_REVERB_PORT="${REVERB_PORT}"
+VITE_REVERB_SCHEME="${REVERB_SCHEME}"
+
+# ── Trusted proxies (Nginx sits in front of PHP-FPM) ─────────────────────────
+TRUSTED_PROXIES=127.0.0.1
+
+# ── Misc ──────────────────────────────────────────────────────────────────────
+BCRYPT_ROUNDS=12

--- a/deploy/logrotate.conf
+++ b/deploy/logrotate.conf
@@ -1,0 +1,15 @@
+# /etc/logrotate.d/watchboard
+#
+# Rotates Laravel application logs daily, keeps 30 days compressed.
+
+/var/www/watchboard/storage/logs/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    create 0664 www-data www-data
+    su www-data www-data
+}

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,84 @@
+# /etc/nginx/sites-available/watchboard
+# Symlink: ln -s /etc/nginx/sites-available/watchboard /etc/nginx/sites-enabled/
+#
+# Assumes certbot has already issued a certificate:
+#   certbot --nginx -d watchboard.app -d www.watchboard.app
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name watchboard.app www.watchboard.app;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name watchboard.app www.watchboard.app;
+
+    root /var/www/watchboard/public;
+    index index.php;
+
+    # SSL — managed by certbot
+    ssl_certificate     /etc/letsencrypt/live/watchboard.app/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/watchboard.app/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Security headers
+    add_header X-Frame-Options           "SAMEORIGIN"  always;
+    add_header X-Content-Type-Options    "nosniff"     always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+    add_header X-XSS-Protection          "1; mode=block" always;
+
+    charset utf-8;
+    client_max_body_size 20M;
+
+    # Static assets — long cache
+    location ~* \.(css|js|woff2?|ttf|svg|png|jpg|jpeg|gif|ico|webp)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # Laravel router
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    # PHP-FPM
+    location ~ \.php$ {
+        fastcgi_pass   unix:/run/php/php8.4-fpm.sock;
+        fastcgi_param  SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include        fastcgi_params;
+        fastcgi_hide_header X-Powered-By;
+        fastcgi_read_timeout 300;
+    }
+
+    # Reverb WebSocket — proxy to local port 8080
+    location /app {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host       $host;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # Deny hidden files (except .well-known for certbot)
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+
+    access_log /var/log/nginx/watchboard.access.log;
+    error_log  /var/log/nginx/watchboard.error.log;
+}

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# =============================================================================
+# WatchBoard — Fresh-server setup script
+# Target: Ubuntu 24.04 LTS (Hetzner CX22 / DigitalOcean Droplet / any VPS)
+# Run as root: bash deploy/setup.sh
+# =============================================================================
+set -euo pipefail
+
+APP_USER="deploy"
+APP_DIR="/var/www/watchboard"
+PHP="8.4"
+NODE="20"
+DOMAIN="watchboard.app"
+REPO="https://github.com/gemanzo/watchboard.git"   # change if private
+
+info()  { echo -e "\n\033[1;34m▶ $*\033[0m"; }
+ok()    { echo -e "\033[1;32m✔ $*\033[0m"; }
+die()   { echo -e "\033[1;31m✖ $*\033[0m" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "Run as root (sudo bash deploy/setup.sh)"
+
+# ── 1. System update ──────────────────────────────────────────────────────────
+info "Updating system packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq && apt-get upgrade -y -qq
+apt-get install -y -qq curl wget git unzip supervisor logrotate ufw fail2ban
+
+# ── 2. PHP 8.4 ───────────────────────────────────────────────────────────────
+info "Installing PHP $PHP"
+add-apt-repository -y ppa:ondrej/php
+apt-get update -qq
+apt-get install -y -qq \
+  php${PHP}-fpm php${PHP}-cli \
+  php${PHP}-pgsql php${PHP}-redis \
+  php${PHP}-mbstring php${PHP}-xml php${PHP}-curl \
+  php${PHP}-zip php${PHP}-bcmath php${PHP}-pcntl \
+  php${PHP}-intl php${PHP}-gd
+
+# Tune PHP-FPM for production
+sed -i 's/^;pm.max_children.*/pm.max_children = 20/'   /etc/php/${PHP}/fpm/pool.d/www.conf
+sed -i 's/^;pm.start_servers.*/pm.start_servers = 4/'  /etc/php/${PHP}/fpm/pool.d/www.conf
+systemctl enable php${PHP}-fpm && systemctl restart php${PHP}-fpm
+ok "PHP $PHP ready"
+
+# ── 3. Nginx ──────────────────────────────────────────────────────────────────
+info "Installing Nginx"
+apt-get install -y -qq nginx
+systemctl enable nginx
+ok "Nginx ready"
+
+# ── 4. PostgreSQL ─────────────────────────────────────────────────────────────
+info "Installing PostgreSQL"
+apt-get install -y -qq postgresql postgresql-contrib
+systemctl enable postgresql
+
+# Create DB user & database
+sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='watchboard'" \
+  | grep -q 1 || sudo -u postgres psql -c "CREATE USER watchboard WITH CREATEDB;"
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='watchboard'" \
+  | grep -q 1 || sudo -u postgres createdb watchboard -O watchboard
+ok "PostgreSQL ready — set a password: sudo -u postgres psql -c \"\\password watchboard\""
+
+# ── 5. Redis ──────────────────────────────────────────────────────────────────
+info "Installing Redis"
+apt-get install -y -qq redis-server
+systemctl enable redis-server && systemctl start redis-server
+ok "Redis ready"
+
+# ── 6. Node.js $NODE ─────────────────────────────────────────────────────────
+info "Installing Node.js $NODE"
+curl -fsSL https://deb.nodesource.com/setup_${NODE}.x | bash - > /dev/null
+apt-get install -y -qq nodejs
+ok "Node $(node -v) ready"
+
+# ── 7. Composer ───────────────────────────────────────────────────────────────
+info "Installing Composer"
+curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ok "Composer $(composer --version 2>/dev/null | head -1) ready"
+
+# ── 8. Certbot ────────────────────────────────────────────────────────────────
+info "Installing Certbot"
+apt-get install -y -qq certbot python3-certbot-nginx
+ok "Certbot ready"
+
+# ── 9. Deploy user ────────────────────────────────────────────────────────────
+info "Creating deploy user: $APP_USER"
+id "$APP_USER" &>/dev/null || useradd -m -s /bin/bash "$APP_USER"
+usermod -aG www-data "$APP_USER"
+mkdir -p /home/${APP_USER}/.ssh
+chmod 700 /home/${APP_USER}/.ssh
+touch /home/${APP_USER}/.ssh/authorized_keys
+chmod 600 /home/${APP_USER}/.ssh/authorized_keys
+chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}/.ssh
+ok "User $APP_USER created — add SSH key to /home/$APP_USER/.ssh/authorized_keys"
+
+# ── 10. App directory ─────────────────────────────────────────────────────────
+info "Creating app directory: $APP_DIR"
+mkdir -p "$APP_DIR"
+chown -R ${APP_USER}:www-data "$APP_DIR"
+chmod -R 775 "$APP_DIR"
+
+# ── 11. Clone repository ──────────────────────────────────────────────────────
+info "Cloning repository"
+if [[ ! -d "${APP_DIR}/.git" ]]; then
+  sudo -u "$APP_USER" git clone "$REPO" "$APP_DIR"
+else
+  ok "Repo already cloned — skipping"
+fi
+
+# ── 12. Storage & cache dirs ─────────────────────────────────────────────────
+info "Setting up storage permissions"
+sudo -u "$APP_USER" mkdir -p \
+  "${APP_DIR}/storage/app/public" \
+  "${APP_DIR}/storage/framework/cache/data" \
+  "${APP_DIR}/storage/framework/sessions" \
+  "${APP_DIR}/storage/framework/views" \
+  "${APP_DIR}/storage/logs"
+chown -R ${APP_USER}:www-data "${APP_DIR}/storage" "${APP_DIR}/bootstrap/cache"
+chmod -R 775 "${APP_DIR}/storage" "${APP_DIR}/bootstrap/cache"
+
+# ── 13. Supervisor programs ───────────────────────────────────────────────────
+info "Installing Supervisor config"
+cp "${APP_DIR}/deploy/supervisor.conf" /etc/supervisor/conf.d/watchboard.conf
+# Replace /var/www/watchboard if DEPLOY_PATH differs
+sed -i "s|/var/www/watchboard|${APP_DIR}|g" /etc/supervisor/conf.d/watchboard.conf
+systemctl enable supervisor && systemctl start supervisor
+
+# ── 14. Log rotation ─────────────────────────────────────────────────────────
+info "Installing logrotate config"
+cp "${APP_DIR}/deploy/logrotate.conf" /etc/logrotate.d/watchboard
+sed -i "s|/var/www/watchboard|${APP_DIR}|g" /etc/logrotate.d/watchboard
+
+# ── 15. Nginx site ────────────────────────────────────────────────────────────
+info "Installing Nginx site"
+cp "${APP_DIR}/deploy/nginx.conf" /etc/nginx/sites-available/watchboard
+sed -i "s|/var/www/watchboard|${APP_DIR}|g" /etc/nginx/sites-available/watchboard
+ln -sf /etc/nginx/sites-available/watchboard /etc/nginx/sites-enabled/watchboard
+rm -f /etc/nginx/sites-enabled/default
+nginx -t && systemctl reload nginx
+
+# ── 16. Firewall ──────────────────────────────────────────────────────────────
+info "Configuring firewall"
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+ok "UFW enabled (SSH + HTTP/HTTPS open)"
+
+# ── 17. Scheduler cron ───────────────────────────────────────────────────────
+info "Adding Laravel scheduler cron"
+CRON_LINE="* * * * * ${APP_USER} php ${APP_DIR}/artisan schedule:run >> /dev/null 2>&1"
+if ! crontab -l 2>/dev/null | grep -qF "$APP_DIR/artisan schedule:run"; then
+  (crontab -l 2>/dev/null; echo "$CRON_LINE") | crontab -
+fi
+ok "Cron installed"
+
+echo ""
+echo "================================================================"
+echo " Setup complete. Remaining manual steps:"
+echo "================================================================"
+echo ""
+echo " 1. Set PostgreSQL password:"
+echo "    sudo -u postgres psql -c \"\\password watchboard\""
+echo ""
+echo " 2. Copy and fill in .env:"
+echo "    cp ${APP_DIR}/deploy/.env.production.example ${APP_DIR}/.env"
+echo "    nano ${APP_DIR}/.env"
+echo "    # Fill in: APP_KEY, DB_PASSWORD, MAIL_PASSWORD, REVERB_* values"
+echo ""
+echo " 3. Install PHP dependencies & build assets:"
+echo "    cd ${APP_DIR}"
+echo "    sudo -u ${APP_USER} composer install --no-dev --optimize-autoloader"
+echo "    sudo -u ${APP_USER} npm ci && sudo -u ${APP_USER} npm run build"
+echo ""
+echo " 4. Bootstrap Laravel:"
+echo "    cd ${APP_DIR}"
+echo "    sudo -u ${APP_USER} php artisan key:generate"
+echo "    sudo -u ${APP_USER} php artisan migrate --force"
+echo "    sudo -u ${APP_USER} php artisan storage:link"
+echo "    sudo -u ${APP_USER} php artisan config:cache"
+echo "    sudo -u ${APP_USER} php artisan route:cache"
+echo "    sudo -u ${APP_USER} php artisan view:cache"
+echo "    sudo -u ${APP_USER} php artisan event:cache"
+echo ""
+echo " 5. Obtain SSL certificate:"
+echo "    certbot --nginx -d ${DOMAIN} -d www.${DOMAIN}"
+echo ""
+echo " 6. Start Supervisor workers:"
+echo "    supervisorctl reread && supervisorctl update"
+echo "    supervisorctl start watchboard:*"
+echo ""
+echo " 7. Add GitHub Secrets for CD (Settings → Secrets → Actions):"
+echo "    SSH_HOST         = <server IP or hostname>"
+echo "    SSH_USER         = ${APP_USER}"
+echo "    SSH_PRIVATE_KEY  = <private key content>"
+echo "    SSH_PORT         = 22"
+echo "    DEPLOY_PATH      = ${APP_DIR}"
+echo ""
+echo " 8. Seed demo data (optional):"
+echo "    php artisan db:seed --class=DemoSeeder"
+echo ""
+echo " 9. Push to master to trigger the first automated deploy."
+echo ""

--- a/deploy/supervisor.conf
+++ b/deploy/supervisor.conf
@@ -1,0 +1,38 @@
+# /etc/supervisor/conf.d/watchboard.conf
+#
+# After copying: supervisorctl reread && supervisorctl update
+
+# ── Laravel Horizon (queue worker) ────────────────────────────────────────────
+[program:watchboard-horizon]
+process_name=%(program_name)s
+command=php /var/www/watchboard/artisan horizon
+autostart=true
+autorestart=true
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/www/watchboard/storage/logs/horizon.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=5
+stopwaitsecs=3600
+stopsignal=SIGTERM
+stopasgroup=true
+killasgroup=true
+
+# ── Laravel Reverb (WebSocket server on 127.0.0.1:8080) ───────────────────────
+[program:watchboard-reverb]
+process_name=%(program_name)s
+command=php /var/www/watchboard/artisan reverb:start --host=0.0.0.0 --port=8080 --no-interaction
+autostart=true
+autorestart=true
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/www/watchboard/storage/logs/reverb.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=5
+stopsignal=SIGTERM
+stopasgroup=true
+killasgroup=true
+
+# ── Group (start/stop both together) ─────────────────────────────────────────
+[group:watchboard]
+programs=watchboard-horizon,watchboard-reverb


### PR DESCRIPTION
Enable the CD pipeline (removes if:false guard) and add everything
needed to run WatchBoard on a fresh VPS:

- deploy/setup.sh          one-shot Ubuntu 24.04 provisioning script
- deploy/nginx.conf        HTTPS + WebSocket proxy for Reverb (port 443 → 8080)
- deploy/supervisor.conf   Horizon (queue) + Reverb (WebSocket) as daemons
- deploy/logrotate.conf    daily rotation, 30-day retention
- deploy/.env.production.example  production .env template (Resend mail, Redis sessions)

deploy.yml changes:
- remove `if: false` gate
- add `php artisan reverb:restart` after horizon:terminate

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>