### PR TITLE
 US-3.6 · SSL Certificate Monitoring #53

### DIFF
--- a/app/Console/Commands/DispatchSslChecks.php
+++ b/app/Console/Commands/DispatchSslChecks.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\PerformSslCheck;
+use App\Models\Monitor;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Bus\Dispatcher;
+
+class DispatchSslChecks extends Command
+{
+    protected $signature = 'monitors:dispatch-ssl-checks';
+
+    protected $description = 'Dispatch PerformSslCheck jobs for every monitor that has SSL checking enabled.';
+
+    public function handle(): int
+    {
+        $monitors = Monitor::query()
+            ->where('is_paused', false)
+            ->where('ssl_check_enabled', true)
+            ->get();
+
+        foreach ($monitors as $monitor) {
+            app(Dispatcher::class)->dispatch(new PerformSslCheck($monitor));
+        }
+
+        $count = $monitors->count();
+
+        $this->info("Dispatched {$count} SSL check job(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -44,12 +44,18 @@ class MonitorController extends Controller
 
     public function create(Request $request): Response
     {
-        $plan = $request->user()->planConfig();
+        $user = $request->user();
+        $plan = $user->planConfig();
+        $maxSsl = $plan['max_ssl_monitors'] ?? null;
+
+        $sslCheckAvailable = $maxSsl === null
+            || $user->monitors()->where('ssl_check_enabled', true)->count() < $maxSsl;
 
         return Inertia::render('Monitors/Create', [
-            'availableIntervals'         => $plan['intervals'],
-            'maxThreshold'               => (int) $plan['max_confirmation_threshold'],
-            'responseTimeAlertsEnabled'  => (bool) $plan['response_time_alerts'],
+            'availableIntervals'        => $plan['intervals'],
+            'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
+            'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
+            'sslCheckAvailable'         => $sslCheckAvailable,
         ]);
     }
 
@@ -112,7 +118,13 @@ class MonitorController extends Controller
     {
         Gate::authorize('update', $monitor);
 
-        $plan = $request->user()->planConfig();
+        $user = $request->user();
+        $plan = $user->planConfig();
+        $maxSsl = $plan['max_ssl_monitors'] ?? null;
+
+        $sslCheckAvailable = $monitor->ssl_check_enabled
+            || $maxSsl === null
+            || $user->monitors()->where('ssl_check_enabled', true)->where('id', '!=', $monitor->id)->count() < $maxSsl;
 
         return Inertia::render('Monitors/Edit', [
             'monitor'            => [
@@ -131,6 +143,7 @@ class MonitorController extends Controller
             'availableIntervals'        => $plan['intervals'],
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
             'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
+            'sslCheckAvailable'         => $sslCheckAvailable,
         ]);
     }
 

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -78,6 +78,10 @@ class MonitorController extends Controller
                 'duration_seconds' => $incident->duration_seconds,
             ]);
 
+        $sslCheck = $monitor->ssl_check_enabled
+            ? $monitor->latestSslCheck
+            : null;
+
         return Inertia::render('Monitors/Show', [
             'monitor' => [
                 'id'               => $monitor->id,
@@ -87,9 +91,20 @@ class MonitorController extends Controller
                 'interval_minutes' => $monitor->interval_minutes,
                 'current_status'   => $monitor->current_status,
                 'is_paused'        => $monitor->is_paused,
+                'ssl_check_enabled' => $monitor->ssl_check_enabled,
             ],
             'uptime'     => $monitor->uptimeAll(),
             'incidents'  => $incidents,
+            'sslCheck'   => $sslCheck ? [
+                'issuer'            => $sslCheck->issuer,
+                'valid_from'        => $sslCheck->valid_from?->toDateString(),
+                'valid_to'          => $sslCheck->valid_to?->toDateString(),
+                'days_until_expiry' => $sslCheck->days_until_expiry,
+                'is_valid'          => $sslCheck->is_valid,
+                'error'             => $sslCheck->error,
+                'alert_level'       => $sslCheck->alertLevel(),
+                'checked_at'        => $sslCheck->checked_at->diffForHumans(),
+            ] : null,
         ]);
     }
 
@@ -110,6 +125,8 @@ class MonitorController extends Controller
                 'is_paused'              => $monitor->is_paused,
                 'confirmation_threshold'     => $monitor->confirmation_threshold,
                 'response_time_threshold_ms' => $monitor->response_time_threshold_ms,
+                'ssl_check_enabled'          => $monitor->ssl_check_enabled,
+                'ssl_expiry_alert_days'      => $monitor->ssl_expiry_alert_days,
             ],
             'availableIntervals'        => $plan['intervals'],
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -12,6 +12,27 @@ class StoreMonitorRequest extends FormRequest
         return $this->user()->can('create', Monitor::class);
     }
 
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            if (! $this->boolean('ssl_check_enabled')) {
+                return;
+            }
+
+            $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
+
+            if ($maxSsl === null) {
+                return;
+            }
+
+            $used = $this->user()->monitors()->where('ssl_check_enabled', true)->count();
+
+            if ($used >= $maxSsl) {
+                $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+            }
+        });
+    }
+
     public function rules(): array
     {
         $plan         = $this->user()->planConfig();

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -28,6 +28,8 @@ class StoreMonitorRequest extends FormRequest
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'ssl_check_enabled'    => ['boolean'],
+            'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -28,6 +28,8 @@ class UpdateMonitorRequest extends FormRequest
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'ssl_check_enabled'     => ['boolean'],
+            'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -12,6 +12,37 @@ class UpdateMonitorRequest extends FormRequest
         return $this->user()->can('update', $this->route('monitor'));
     }
 
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            if (! $this->boolean('ssl_check_enabled')) {
+                return;
+            }
+
+            /** @var \App\Models\Monitor $monitor */
+            $monitor = $this->route('monitor');
+
+            if ($monitor->ssl_check_enabled) {
+                return;
+            }
+
+            $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
+
+            if ($maxSsl === null) {
+                return;
+            }
+
+            $used = $this->user()->monitors()
+                ->where('ssl_check_enabled', true)
+                ->where('id', '!=', $monitor->id)
+                ->count();
+
+            if ($used >= $maxSsl) {
+                $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+            }
+        });
+    }
+
     public function rules(): array
     {
         $plan         = $this->user()->planConfig();

--- a/app/Jobs/PerformSslCheck.php
+++ b/app/Jobs/PerformSslCheck.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Monitor;
+use App\Models\SslCheck;
+use App\Notifications\SslExpiringNotification;
+use Carbon\Carbon;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class PerformSslCheck implements ShouldQueue, ShouldBeUnique
+{
+    use Queueable;
+
+    public int $tries = 3;
+    public array $backoff = [10, 60];
+
+    public function __construct(public readonly Monitor $monitor)
+    {
+        $this->onQueue('checks');
+    }
+
+    public function uniqueId(): string
+    {
+        return 'ssl-' . $this->monitor->id;
+    }
+
+    public function handle(): void
+    {
+        $result = $this->fetchCertificate();
+
+        $sslCheck = $this->monitor->sslChecks()->create([
+            'issuer'            => $result['issuer'],
+            'valid_from'        => $result['valid_from'],
+            'valid_to'          => $result['valid_to'],
+            'days_until_expiry' => $result['days_until_expiry'],
+            'is_valid'          => $result['is_valid'],
+            'error'             => $result['error'],
+            'checked_at'        => now(),
+        ]);
+
+        $this->notifyIfNeeded($sslCheck);
+    }
+
+    protected function fetchCertificate(): array
+    {
+        $host    = parse_url($this->monitor->url, PHP_URL_HOST);
+        $port    = parse_url($this->monitor->url, PHP_URL_PORT) ?? 443;
+        $timeout = 10;
+
+        $context = stream_context_create([
+            'ssl' => [
+                'capture_peer_cert' => true,
+                'verify_peer'       => true,
+                'verify_peer_name'  => true,
+            ],
+        ]);
+
+        $client = @stream_socket_client(
+            "ssl://{$host}:{$port}",
+            $errno,
+            $errstr,
+            $timeout,
+            STREAM_CLIENT_CONNECT,
+            $context,
+        );
+
+        if ($client === false) {
+            return [
+                'issuer'            => null,
+                'valid_from'        => null,
+                'valid_to'          => null,
+                'days_until_expiry' => null,
+                'is_valid'          => false,
+                'error'             => $errstr ?: "Connection failed (errno {$errno})",
+            ];
+        }
+
+        $params = stream_context_get_params($client);
+        fclose($client);
+
+        $cert = $params['options']['ssl']['peer_certificate'] ?? null;
+
+        if ($cert === null) {
+            return [
+                'issuer'            => null,
+                'valid_from'        => null,
+                'valid_to'          => null,
+                'days_until_expiry' => null,
+                'is_valid'          => false,
+                'error'             => 'No certificate captured',
+            ];
+        }
+
+        $info    = openssl_x509_parse($cert);
+        $validTo = Carbon::createFromTimestamp($info['validTo_time_t']);
+        $validFrom = Carbon::createFromTimestamp($info['validFrom_time_t']);
+        $daysUntilExpiry = (int) now()->diffInDays($validTo, false);
+        $issuer  = $this->extractIssuer($info['issuer'] ?? []);
+
+        return [
+            'issuer'            => $issuer,
+            'valid_from'        => $validFrom,
+            'valid_to'          => $validTo,
+            'days_until_expiry' => $daysUntilExpiry,
+            'is_valid'          => $daysUntilExpiry > 0,
+            'error'             => null,
+        ];
+    }
+
+    protected function extractIssuer(array $issuer): ?string
+    {
+        return $issuer['O'] ?? $issuer['CN'] ?? null;
+    }
+
+    private function notifyIfNeeded(SslCheck $sslCheck): void
+    {
+        $alertLevel = $sslCheck->alertLevel();
+
+        if ($alertLevel === 'ok') {
+            return;
+        }
+
+        $threshold = $this->monitor->ssl_expiry_alert_days;
+
+        // Only notify when days_until_expiry is at or crosses the configured threshold,
+        // or when the cert is expired/invalid.
+        if (
+            $alertLevel !== 'expired'
+            && $sslCheck->days_until_expiry !== null
+            && $sslCheck->days_until_expiry > $threshold
+        ) {
+            return;
+        }
+
+        $this->monitor->user->notify(new SslExpiringNotification($this->monitor, $sslCheck));
+    }
+}

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Support\Facades\Cache;
 
 class Monitor extends Model
@@ -25,6 +26,8 @@ class Monitor extends Model
         'confirmation_threshold',
         'consecutive_failures',
         'response_time_threshold_ms',
+        'ssl_check_enabled',
+        'ssl_expiry_alert_days',
     ];
 
     protected function casts(): array
@@ -35,6 +38,8 @@ class Monitor extends Model
             'confirmation_threshold'     => 'integer',
             'consecutive_failures'       => 'integer',
             'response_time_threshold_ms' => 'integer',
+            'ssl_check_enabled'          => 'boolean',
+            'ssl_expiry_alert_days'      => 'integer',
         ];
     }
 
@@ -56,6 +61,16 @@ class Monitor extends Model
     public function latestCheckResult(): HasOne
     {
         return $this->hasOne(CheckResult::class)->latestOfMany('checked_at');
+    }
+
+    public function sslChecks(): HasMany
+    {
+        return $this->hasMany(SslCheck::class);
+    }
+
+    public function latestSslCheck(): HasOne
+    {
+        return $this->hasOne(SslCheck::class)->latestOfMany('checked_at');
     }
 
     public function uptimePercentage(string $range): ?float

--- a/app/Models/SslCheck.php
+++ b/app/Models/SslCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SslCheck extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'monitor_id',
+        'issuer',
+        'valid_from',
+        'valid_to',
+        'days_until_expiry',
+        'is_valid',
+        'error',
+        'checked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'valid_from'        => 'datetime',
+            'valid_to'          => 'datetime',
+            'days_until_expiry' => 'integer',
+            'is_valid'          => 'boolean',
+            'checked_at'        => 'datetime',
+        ];
+    }
+
+    public function monitor(): BelongsTo
+    {
+        return $this->belongsTo(Monitor::class);
+    }
+
+    public function alertLevel(): string
+    {
+        if (! $this->is_valid) {
+            return 'expired';
+        }
+
+        if ($this->days_until_expiry !== null && $this->days_until_expiry <= 7) {
+            return 'critical';
+        }
+
+        if ($this->days_until_expiry !== null && $this->days_until_expiry <= 14) {
+            return 'warning';
+        }
+
+        return 'ok';
+    }
+}

--- a/app/Notifications/SslExpiringNotification.php
+++ b/app/Notifications/SslExpiringNotification.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Monitor;
+use App\Models\SslCheck;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SslExpiringNotification extends Notification implements ShouldQueue
+{
+    public function __construct(
+        public readonly Monitor  $monitor,
+        public readonly SslCheck $sslCheck,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function viaQueues(): array
+    {
+        return ['mail' => 'notifications'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $alertLevel = $this->sslCheck->alertLevel();
+
+        return match ($alertLevel) {
+            'expired'  => $this->expiredMail(),
+            'critical' => $this->criticalMail(),
+            default    => $this->warningMail(),
+        };
+    }
+
+    private function displayName(): string
+    {
+        return $this->monitor->name ?? $this->monitor->url;
+    }
+
+    private function expiredMail(): MailMessage
+    {
+        $name = $this->displayName();
+
+        return (new MailMessage)
+            ->subject("[WatchBoard] SSL certificate EXPIRED — {$name}")
+            ->greeting('SSL Certificate Expired')
+            ->line("The SSL certificate for **{$name}** has expired or is invalid.")
+            ->line("**URL:** {$this->monitor->url}")
+            ->line($this->sslCheck->error
+                ? "**Error:** {$this->sslCheck->error}"
+                : "**Expired on:** {$this->sslCheck->valid_to?->toDateString()}")
+            ->line('Visitors will see a security warning. Renew the certificate immediately.')
+            ->salutation('— WatchBoard');
+    }
+
+    private function criticalMail(): MailMessage
+    {
+        $name = $this->displayName();
+        $days = $this->sslCheck->days_until_expiry;
+
+        return (new MailMessage)
+            ->subject("[WatchBoard] SSL expiring in {$days}d — {$name}")
+            ->greeting('SSL Certificate Expiring Soon (Critical)')
+            ->line("The SSL certificate for **{$name}** expires in **{$days} days**.")
+            ->line("**URL:** {$this->monitor->url}")
+            ->line("**Issuer:** " . ($this->sslCheck->issuer ?? '—'))
+            ->line("**Expires on:** {$this->sslCheck->valid_to?->toDateString()}")
+            ->line('Renew the certificate as soon as possible to avoid service disruption.')
+            ->salutation('— WatchBoard');
+    }
+
+    private function warningMail(): MailMessage
+    {
+        $name = $this->displayName();
+        $days = $this->sslCheck->days_until_expiry;
+
+        return (new MailMessage)
+            ->subject("[WatchBoard] SSL expiring in {$days}d — {$name}")
+            ->greeting('SSL Certificate Expiring Soon')
+            ->line("The SSL certificate for **{$name}** expires in **{$days} days**.")
+            ->line("**URL:** {$this->monitor->url}")
+            ->line("**Issuer:** " . ($this->sslCheck->issuer ?? '—'))
+            ->line("**Expires on:** {$this->sslCheck->valid_to?->toDateString()}")
+            ->line('Plan your renewal to avoid any disruption.')
+            ->salutation('— WatchBoard');
+    }
+}

--- a/config/plans.php
+++ b/config/plans.php
@@ -2,12 +2,13 @@
 
 return [
     'free' => [
-        'max_monitors'              => 5,
-        'min_interval_minutes'      => 5,
-        'max_status_pages'          => 1,
-        'intervals'                 => [5],
-        'max_confirmation_threshold'  => 1,
-        'response_time_alerts'        => false,
+        'max_monitors'               => 5,
+        'min_interval_minutes'       => 5,
+        'max_status_pages'           => 1,
+        'intervals'                  => [5],
+        'max_confirmation_threshold' => 1,
+        'response_time_alerts'       => false,
+        'max_ssl_monitors'           => 1,
     ],
     'pro' => [
         'max_monitors'               => null,
@@ -16,5 +17,6 @@ return [
         'intervals'                  => [1, 2, 3, 5],
         'max_confirmation_threshold' => 3,
         'response_time_alerts'       => true,
+        'max_ssl_monitors'           => null,
     ],
 ];

--- a/database/factories/MonitorFactory.php
+++ b/database/factories/MonitorFactory.php
@@ -25,6 +25,8 @@ class MonitorFactory extends Factory
             'confirmation_threshold'     => 1,
             'consecutive_failures'       => 0,
             'response_time_threshold_ms' => null,
+            'ssl_check_enabled'          => false,
+            'ssl_expiry_alert_days'      => 14,
         ];
     }
 

--- a/database/factories/SslCheckFactory.php
+++ b/database/factories/SslCheckFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Monitor;
+use App\Models\SslCheck;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SslCheck>
+ */
+class SslCheckFactory extends Factory
+{
+    public function definition(): array
+    {
+        $validTo = now()->addDays(60);
+
+        return [
+            'monitor_id'        => Monitor::factory(),
+            'issuer'            => 'Let\'s Encrypt',
+            'valid_from'        => now()->subDays(30),
+            'valid_to'          => $validTo,
+            'days_until_expiry' => 60,
+            'is_valid'          => true,
+            'error'             => null,
+            'checked_at'        => now(),
+        ];
+    }
+
+    public function expiring(int $daysLeft = 10): static
+    {
+        return $this->state([
+            'valid_to'          => now()->addDays($daysLeft),
+            'days_until_expiry' => $daysLeft,
+            'is_valid'          => true,
+            'error'             => null,
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state([
+            'valid_to'          => now()->subDays(5),
+            'days_until_expiry' => -5,
+            'is_valid'          => false,
+            'error'             => null,
+        ]);
+    }
+
+    public function failed(string $error = 'Connection failed'): static
+    {
+        return $this->state([
+            'issuer'            => null,
+            'valid_from'        => null,
+            'valid_to'          => null,
+            'days_until_expiry' => null,
+            'is_valid'          => false,
+            'error'             => $error,
+        ]);
+    }
+}

--- a/database/migrations/2026_05_05_100000_add_ssl_fields_to_monitors_table.php
+++ b/database/migrations/2026_05_05_100000_add_ssl_fields_to_monitors_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->boolean('ssl_check_enabled')->default(false)->after('response_time_threshold_ms');
+            $table->unsignedTinyInteger('ssl_expiry_alert_days')->default(14)->after('ssl_check_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->dropColumn(['ssl_check_enabled', 'ssl_expiry_alert_days']);
+        });
+    }
+};

--- a/database/migrations/2026_05_05_100001_create_ssl_checks_table.php
+++ b/database/migrations/2026_05_05_100001_create_ssl_checks_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ssl_checks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('monitor_id')->constrained()->cascadeOnDelete();
+            $table->string('issuer')->nullable();
+            $table->timestamp('valid_from')->nullable();
+            $table->timestamp('valid_to')->nullable();
+            $table->integer('days_until_expiry')->nullable();
+            $table->boolean('is_valid');
+            $table->string('error')->nullable();
+            $table->timestamp('checked_at');
+            $table->timestamps();
+
+            $table->index(['monitor_id', 'checked_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ssl_checks');
+    }
+};

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -24,6 +24,8 @@ const form = useForm({
     interval_minutes:            props.availableIntervals[0],
     confirmation_threshold:      1,
     response_time_threshold_ms:  null as number | null,
+    ssl_check_enabled:           false,
+    ssl_expiry_alert_days:       14,
 });
 
 const submit = () => {
@@ -168,6 +170,45 @@ function isIntervalLocked(minutes: number): boolean {
                                     Ricevi un alert quando la risposta supera questa soglia. Lascia vuoto per disabilitare.
                                 </p>
                                 <InputError class="mt-2" :message="form.errors.response_time_threshold_ms" />
+                            </div>
+
+                            <!-- SSL monitoring -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-3">
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        :aria-checked="form.ssl_check_enabled"
+                                        @click="form.ssl_check_enabled = !form.ssl_check_enabled"
+                                        class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                        :class="form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                    >
+                                        <span
+                                            class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                                            :class="form.ssl_check_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                        />
+                                    </button>
+                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="form.ssl_check_enabled = !form.ssl_check_enabled" />
+                                </div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">
+                                    Controlla la scadenza del certificato SSL ogni giorno e invia un alert prima che scada.
+                                </p>
+
+                                <div v-if="form.ssl_check_enabled">
+                                    <InputLabel for="ssl_expiry_alert_days" value="Giorni di preavviso scadenza" />
+                                    <div class="relative mt-1">
+                                        <input
+                                            id="ssl_expiry_alert_days"
+                                            type="number"
+                                            min="1"
+                                            max="90"
+                                            v-model.number="form.ssl_expiry_alert_days"
+                                            class="block w-full rounded-md border-gray-300 pr-14 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                        />
+                                        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-sm text-gray-400">giorni</span>
+                                    </div>
+                                    <InputError class="mt-2" :message="form.errors.ssl_expiry_alert_days" />
+                                </div>
                             </div>
 
                             <!-- Actions -->

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
     availableIntervals: number[];
     maxThreshold: number;
     responseTimeAlertsEnabled: boolean;
+    sslCheckAvailable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -179,16 +180,18 @@ function isIntervalLocked(minutes: number): boolean {
                                         type="button"
                                         role="switch"
                                         :aria-checked="form.ssl_check_enabled"
-                                        @click="form.ssl_check_enabled = !form.ssl_check_enabled"
+                                        :disabled="!sslCheckAvailable"
+                                        @click="sslCheckAvailable && (form.ssl_check_enabled = !form.ssl_check_enabled)"
                                         class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                                        :class="form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                        :class="[form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700', !sslCheckAvailable ? 'cursor-not-allowed opacity-50' : '']"
                                     >
                                         <span
                                             class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
                                             :class="form.ssl_check_enabled ? 'translate-x-6' : 'translate-x-1'"
                                         />
                                     </button>
-                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="form.ssl_check_enabled = !form.ssl_check_enabled" />
+                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="sslCheckAvailable && (form.ssl_check_enabled = !form.ssl_check_enabled)" />
+                                    <ProBadge v-if="!sslCheckAvailable" />
                                 </div>
                                 <p class="text-sm text-gray-500 dark:text-gray-400">
                                     Controlla la scadenza del certificato SSL ogni giorno e invia un alert prima che scada.

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -23,6 +23,8 @@ interface Monitor {
     is_paused: boolean;
     confirmation_threshold: number;
     response_time_threshold_ms: number | null;
+    ssl_check_enabled: boolean;
+    ssl_expiry_alert_days: number;
 }
 
 const props = defineProps<{
@@ -41,6 +43,8 @@ const form = useForm({
     interval_minutes:           props.monitor.interval_minutes,
     confirmation_threshold:     props.monitor.confirmation_threshold,
     response_time_threshold_ms: props.monitor.response_time_threshold_ms,
+    ssl_check_enabled:          props.monitor.ssl_check_enabled,
+    ssl_expiry_alert_days:      props.monitor.ssl_expiry_alert_days,
 });
 
 const submit = () => {
@@ -204,6 +208,45 @@ function isIntervalLocked(minutes: number): boolean {
                                     Ricevi un alert quando la risposta supera questa soglia. Lascia vuoto per disabilitare.
                                 </p>
                                 <InputError class="mt-2" :message="form.errors.response_time_threshold_ms" />
+                            </div>
+
+                            <!-- SSL monitoring -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-3">
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        :aria-checked="form.ssl_check_enabled"
+                                        @click="form.ssl_check_enabled = !form.ssl_check_enabled"
+                                        class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                        :class="form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                    >
+                                        <span
+                                            class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                                            :class="form.ssl_check_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                        />
+                                    </button>
+                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="form.ssl_check_enabled = !form.ssl_check_enabled" />
+                                </div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">
+                                    Controlla la scadenza del certificato SSL ogni giorno e invia un alert prima che scada.
+                                </p>
+
+                                <div v-if="form.ssl_check_enabled">
+                                    <InputLabel for="ssl_expiry_alert_days" value="Giorni di preavviso scadenza" />
+                                    <div class="relative mt-1">
+                                        <input
+                                            id="ssl_expiry_alert_days"
+                                            type="number"
+                                            min="1"
+                                            max="90"
+                                            v-model.number="form.ssl_expiry_alert_days"
+                                            class="block w-full rounded-md border-gray-300 pr-14 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                        />
+                                        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-sm text-gray-400">giorni</span>
+                                    </div>
+                                    <InputError class="mt-2" :message="form.errors.ssl_expiry_alert_days" />
+                                </div>
                             </div>
 
                             <!-- Actions -->

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
     availableIntervals: number[];
     maxThreshold: number;
     responseTimeAlertsEnabled: boolean;
+    sslCheckAvailable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -217,16 +218,18 @@ function isIntervalLocked(minutes: number): boolean {
                                         type="button"
                                         role="switch"
                                         :aria-checked="form.ssl_check_enabled"
-                                        @click="form.ssl_check_enabled = !form.ssl_check_enabled"
+                                        :disabled="!sslCheckAvailable"
+                                        @click="sslCheckAvailable && (form.ssl_check_enabled = !form.ssl_check_enabled)"
                                         class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                                        :class="form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                        :class="[form.ssl_check_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700', !sslCheckAvailable ? 'cursor-not-allowed opacity-50' : '']"
                                     >
                                         <span
                                             class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
                                             :class="form.ssl_check_enabled ? 'translate-x-6' : 'translate-x-1'"
                                         />
                                     </button>
-                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="form.ssl_check_enabled = !form.ssl_check_enabled" />
+                                    <InputLabel value="Monitoraggio SSL" class="!mb-0 cursor-pointer" @click="sslCheckAvailable && (form.ssl_check_enabled = !form.ssl_check_enabled)" />
+                                    <ProBadge v-if="!sslCheckAvailable" />
                                 </div>
                                 <p class="text-sm text-gray-500 dark:text-gray-400">
                                     Controlla la scadenza del certificato SSL ogni giorno e invia un alert prima che scada.

--- a/resources/js/Pages/Monitors/Show.vue
+++ b/resources/js/Pages/Monitors/Show.vue
@@ -28,6 +28,18 @@ interface Monitor {
     interval_minutes: number;
     current_status: 'unknown' | 'up' | 'down';
     is_paused: boolean;
+    ssl_check_enabled: boolean;
+}
+
+interface SslCheck {
+    issuer: string | null;
+    valid_from: string | null;
+    valid_to: string | null;
+    days_until_expiry: number | null;
+    is_valid: boolean;
+    error: string | null;
+    alert_level: 'ok' | 'warning' | 'critical' | 'expired';
+    checked_at: string;
 }
 
 interface MetricPoint {
@@ -55,6 +67,7 @@ const props = defineProps<{
     monitor: Monitor;
     uptime: Uptime;
     incidents: Incident[];
+    sslCheck: SslCheck | null;
 }>();
 
 function formatDate(iso: string): string {
@@ -281,6 +294,87 @@ watch(metrics, (pts) => {
                             </dd>
                         </div>
                     </dl>
+                </div>
+
+                <!-- SSL Certificate -->
+                <div v-if="monitor.ssl_check_enabled" class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-700 flex items-center justify-between">
+                        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
+                            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+                            </svg>
+                            Certificato SSL
+                        </h3>
+                        <span v-if="sslCheck" class="text-xs text-gray-400 dark:text-gray-500">
+                            aggiornato {{ sslCheck.checked_at }}
+                        </span>
+                    </div>
+
+                    <!-- No data yet -->
+                    <div v-if="!sslCheck" class="flex flex-col items-center justify-center py-10 text-center">
+                        <svg class="mb-3 h-8 w-8 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        </svg>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">In attesa del primo check SSL</p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Il check viene eseguito automaticamente ogni giorno.</p>
+                    </div>
+
+                    <!-- SSL data -->
+                    <div v-else class="p-6">
+                        <div class="flex flex-wrap items-start gap-6">
+                            <!-- Badge -->
+                            <div class="flex flex-col items-center gap-1.5 min-w-[80px]">
+                                <span
+                                    class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold"
+                                    :class="{
+                                        'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300': sslCheck.alert_level === 'ok',
+                                        'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300': sslCheck.alert_level === 'warning',
+                                        'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300': sslCheck.alert_level === 'critical',
+                                        'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300': sslCheck.alert_level === 'expired',
+                                    }"
+                                >
+                                    <svg class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20">
+                                        <circle v-if="sslCheck.alert_level === 'ok'" cx="10" cy="10" r="7" fill="currentColor" />
+                                        <path v-else fill-rule="evenodd" clip-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" />
+                                    </svg>
+                                    <span>
+                                        {{ sslCheck.alert_level === 'ok' ? 'Valido' : sslCheck.alert_level === 'warning' ? 'In scadenza' : sslCheck.alert_level === 'critical' ? 'Critico' : 'Scaduto' }}
+                                    </span>
+                                </span>
+                                <span v-if="sslCheck.days_until_expiry !== null && sslCheck.is_valid" class="text-xs text-gray-400">
+                                    {{ sslCheck.days_until_expiry }}g rimasti
+                                </span>
+                            </div>
+
+                            <!-- Details grid -->
+                            <dl class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3 flex-1">
+                                <div v-if="sslCheck.issuer">
+                                    <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Emesso da</dt>
+                                    <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ sslCheck.issuer }}</dd>
+                                </div>
+                                <div v-if="sslCheck.valid_from">
+                                    <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Valido dal</dt>
+                                    <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ sslCheck.valid_from }}</dd>
+                                </div>
+                                <div v-if="sslCheck.valid_to">
+                                    <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Scade il</dt>
+                                    <dd
+                                        class="mt-1 font-medium"
+                                        :class="{
+                                            'text-gray-700 dark:text-gray-200': sslCheck.alert_level === 'ok',
+                                            'text-yellow-600 dark:text-yellow-400': sslCheck.alert_level === 'warning',
+                                            'text-orange-600 dark:text-orange-400': sslCheck.alert_level === 'critical',
+                                            'text-red-600 dark:text-red-400': sslCheck.alert_level === 'expired',
+                                        }"
+                                    >{{ sslCheck.valid_to }}</dd>
+                                </div>
+                                <div v-if="sslCheck.error" class="col-span-full">
+                                    <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Errore</dt>
+                                    <dd class="mt-1 text-red-600 dark:text-red-400 font-mono text-xs">{{ sslCheck.error }}</dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Uptime -->

--- a/routes/console.php
+++ b/routes/console.php
@@ -12,3 +12,8 @@ Schedule::command('monitors:dispatch-checks')
     ->everyMinute()
     ->withoutOverlapping()
     ->runInBackground();
+
+Schedule::command('monitors:dispatch-ssl-checks')
+    ->dailyAt('03:00')
+    ->withoutOverlapping()
+    ->runInBackground();

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ Route::get('/', function () {
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [MonitorController::class, 'index'])->name('dashboard');
-    Route::redirect('/monitors', '/dashboard')->name('monitors.index');
+    Route::get('/monitors', fn () => to_route('dashboard'))->name('monitors.index');
     Route::get('/monitors/create', [MonitorController::class, 'create'])->name('monitors.create');
     Route::post('/monitors', [MonitorController::class, 'store'])
         ->middleware('check.plan.limits:monitors')

--- a/tests/Feature/SslMonitoringTest.php
+++ b/tests/Feature/SslMonitoringTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use App\Jobs\PerformSslCheck;
+use App\Models\Monitor;
+use App\Models\SslCheck;
+use App\Models\User;
+use App\Notifications\SslExpiringNotification;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+
+// ─── Test subclass ────────────────────────────────────────────────────────────
+
+class FakeSslCheck extends PerformSslCheck
+{
+    public function __construct(Monitor $monitor, private readonly array $fakeData)
+    {
+        parent::__construct($monitor);
+    }
+
+    protected function fetchCertificate(): array
+    {
+        return $this->fakeData;
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function sslMonitor(int $alertDays = 14): Monitor
+{
+    return Monitor::factory()->create([
+        'user_id'               => User::factory(),
+        'url'                   => 'https://example.com',
+        'ssl_check_enabled'     => true,
+        'ssl_expiry_alert_days' => $alertDays,
+        'is_paused'             => false,
+    ]);
+}
+
+function makeSslJob(Monitor $monitor, array $certData): FakeSslCheck
+{
+    return new FakeSslCheck($monitor, $certData);
+}
+
+function validCert(int $daysLeft = 60): array
+{
+    return [
+        'issuer'            => "Let's Encrypt",
+        'valid_from'        => now()->subDays(30),
+        'valid_to'          => now()->addDays($daysLeft),
+        'days_until_expiry' => $daysLeft,
+        'is_valid'          => true,
+        'error'             => null,
+    ];
+}
+
+function expiredCert(): array
+{
+    return [
+        'issuer'            => "Let's Encrypt",
+        'valid_from'        => now()->subDays(400),
+        'valid_to'          => now()->subDays(5),
+        'days_until_expiry' => -5,
+        'is_valid'          => false,
+        'error'             => null,
+    ];
+}
+
+function failedCert(string $error = 'Connection failed'): array
+{
+    return [
+        'issuer'            => null,
+        'valid_from'        => null,
+        'valid_to'          => null,
+        'days_until_expiry' => null,
+        'is_valid'          => false,
+        'error'             => $error,
+    ];
+}
+
+// ─── SslCheck::alertLevel() ───────────────────────────────────────────────────
+
+test('alert level is ok for a cert expiring in 60 days', function () {
+    $check = new SslCheck(['days_until_expiry' => 60, 'is_valid' => true]);
+    expect($check->alertLevel())->toBe('ok');
+});
+
+test('alert level is warning for a cert expiring in 14 days', function () {
+    $check = new SslCheck(['days_until_expiry' => 14, 'is_valid' => true]);
+    expect($check->alertLevel())->toBe('warning');
+});
+
+test('alert level is warning for a cert expiring between 8 and 14 days', function () {
+    $check = new SslCheck(['days_until_expiry' => 8, 'is_valid' => true]);
+    expect($check->alertLevel())->toBe('warning');
+});
+
+test('alert level is critical for a cert expiring in 7 days', function () {
+    $check = new SslCheck(['days_until_expiry' => 7, 'is_valid' => true]);
+    expect($check->alertLevel())->toBe('critical');
+});
+
+test('alert level is critical for a cert expiring in 1 day', function () {
+    $check = new SslCheck(['days_until_expiry' => 1, 'is_valid' => true]);
+    expect($check->alertLevel())->toBe('critical');
+});
+
+test('alert level is expired when is_valid is false', function () {
+    $check = new SslCheck(['days_until_expiry' => -5, 'is_valid' => false]);
+    expect($check->alertLevel())->toBe('expired');
+});
+
+test('alert level is expired when connection failed', function () {
+    $check = new SslCheck(['days_until_expiry' => null, 'is_valid' => false]);
+    expect($check->alertLevel())->toBe('expired');
+});
+
+// ─── PerformSslCheck: saves ssl_check record ──────────────────────────────────
+
+test('saves ssl check record with valid certificate data', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor();
+    $job     = makeSslJob($monitor, validCert(60));
+    $job->handle();
+
+    $check = SslCheck::where('monitor_id', $monitor->id)->sole();
+    expect($check->issuer)->toBe("Let's Encrypt")
+        ->and($check->days_until_expiry)->toBe(60)
+        ->and($check->is_valid)->toBeTrue()
+        ->and($check->error)->toBeNull()
+        ->and($check->checked_at)->not->toBeNull();
+});
+
+test('saves ssl check record for expired certificate', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor();
+    $job     = makeSslJob($monitor, expiredCert());
+    $job->handle();
+
+    $check = SslCheck::where('monitor_id', $monitor->id)->sole();
+    expect($check->is_valid)->toBeFalse()
+        ->and($check->days_until_expiry)->toBe(-5);
+});
+
+test('saves ssl check record for connection failure', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor();
+    $job     = makeSslJob($monitor, failedCert('SSL handshake error'));
+    $job->handle();
+
+    $check = SslCheck::where('monitor_id', $monitor->id)->sole();
+    expect($check->is_valid)->toBeFalse()
+        ->and($check->error)->toBe('SSL handshake error')
+        ->and($check->issuer)->toBeNull();
+});
+
+// ─── PerformSslCheck: notification logic ─────────────────────────────────────
+
+test('no notification when certificate is healthy', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(14);
+    $job     = makeSslJob($monitor, validCert(60));
+    $job->handle();
+
+    Notification::assertNothingSent();
+});
+
+test('sends notification when cert expires within alert threshold (warning)', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(14);
+    $job     = makeSslJob($monitor, validCert(10)); // 10 days < 14 day threshold
+    $job->handle();
+
+    Notification::assertSentTo($monitor->user, SslExpiringNotification::class);
+});
+
+test('sends notification when cert expires within critical threshold', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(14);
+    $job     = makeSslJob($monitor, validCert(5));
+    $job->handle();
+
+    Notification::assertSentTo($monitor->user, SslExpiringNotification::class);
+});
+
+test('sends notification when certificate is expired', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(14);
+    $job     = makeSslJob($monitor, expiredCert());
+    $job->handle();
+
+    Notification::assertSentTo($monitor->user, SslExpiringNotification::class);
+});
+
+test('sends notification when certificate connection fails', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(14);
+    $job     = makeSslJob($monitor, failedCert());
+    $job->handle();
+
+    Notification::assertSentTo($monitor->user, SslExpiringNotification::class);
+});
+
+test('no notification when cert expires after custom alert threshold', function () {
+    Notification::fake();
+
+    $monitor = sslMonitor(7); // only alert within 7 days
+    $job     = makeSslJob($monitor, validCert(10)); // 10 days > 7 day threshold, but <= 14
+    $job->handle();
+
+    Notification::assertNothingSent();
+});
+
+// ─── SslExpiringNotification: mail content ────────────────────────────────────
+
+test('expired notification mail contains EXPIRED in subject', function () {
+    $monitor = Monitor::factory()->create(['name' => 'My Site', 'url' => 'https://example.com']);
+    $check   = SslCheck::factory()->expired()->for($monitor)->create(['checked_at' => now()]);
+
+    $mail = (new SslExpiringNotification($monitor, $check))->toMail($monitor->user);
+
+    expect($mail->subject)->toContain('EXPIRED');
+});
+
+test('warning notification mail contains days until expiry in subject', function () {
+    $monitor = Monitor::factory()->create(['name' => 'My Site', 'url' => 'https://example.com']);
+    $check   = SslCheck::factory()->expiring(10)->for($monitor)->create(['checked_at' => now()]);
+
+    $mail = (new SslExpiringNotification($monitor, $check))->toMail($monitor->user);
+
+    expect($mail->subject)->toContain('10d');
+});
+
+test('critical notification mail contains monitor url in body', function () {
+    $monitor = Monitor::factory()->create(['name' => 'My Site', 'url' => 'https://example.com']);
+    $check   = SslCheck::factory()->expiring(5)->for($monitor)->create(['checked_at' => now()]);
+
+    $mail = (new SslExpiringNotification($monitor, $check))->toMail($monitor->user);
+    $body = collect($mail->introLines)->implode(' ');
+
+    expect($body)->toContain('https://example.com');
+});
+
+test('notification is queued on notifications queue', function () {
+    $monitor = Monitor::factory()->create();
+    $check   = SslCheck::factory()->for($monitor)->create(['checked_at' => now()]);
+
+    $notification = new SslExpiringNotification($monitor, $check);
+
+    expect($notification->viaQueues())->toBe(['mail' => 'notifications']);
+});
+
+test('notification via mail channel', function () {
+    $monitor      = Monitor::factory()->create();
+    $check        = SslCheck::factory()->for($monitor)->create(['checked_at' => now()]);
+    $notification = new SslExpiringNotification($monitor, $check);
+
+    expect($notification->via($monitor->user))->toBe(['mail']);
+});
+
+// ─── DispatchSslChecks command ────────────────────────────────────────────────
+
+test('dispatch ssl checks command dispatches jobs for enabled monitors', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+
+    Monitor::factory()->for($user)->create(['ssl_check_enabled' => true, 'is_paused' => false]);
+    Monitor::factory()->for($user)->create(['ssl_check_enabled' => true, 'is_paused' => false]);
+    Monitor::factory()->for($user)->create(['ssl_check_enabled' => false, 'is_paused' => false]);
+    Monitor::factory()->for($user)->create(['ssl_check_enabled' => true, 'is_paused' => true]);
+
+    $this->artisan('monitors:dispatch-ssl-checks')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(PerformSslCheck::class, 2);
+});
+
+test('dispatch ssl checks command outputs dispatched count', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    Monitor::factory()->for($user)->create(['ssl_check_enabled' => true, 'is_paused' => false]);
+
+    $this->artisan('monitors:dispatch-ssl-checks')
+        ->expectsOutput('Dispatched 1 SSL check job(s).')
+        ->assertExitCode(0);
+});

--- a/tests/Feature/SslPlanLimitTest.php
+++ b/tests/Feature/SslPlanLimitTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use App\Models\Monitor;
+use App\Models\User;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function freeUserSsl(): User
+{
+    return User::factory()->create(['plan' => 'free']);
+}
+
+function proUserSsl(): User
+{
+    return User::factory()->create(['plan' => 'pro']);
+}
+
+function monitorPayload(bool $sslEnabled = true): array
+{
+    return [
+        'name'              => 'Test',
+        'url'               => 'https://example.com',
+        'method'            => 'GET',
+        'interval_minutes'  => 5,
+        'ssl_check_enabled' => $sslEnabled,
+        'ssl_expiry_alert_days' => 14,
+    ];
+}
+
+// ─── Create form ──────────────────────────────────────────────────────────────
+
+test('create form passes sslCheckAvailable=true when free user has no ssl monitors', function () {
+    $user = freeUserSsl();
+
+    $this->actingAs($user)
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('sslCheckAvailable', true)
+        );
+});
+
+test('create form passes sslCheckAvailable=false when free user has used ssl slot', function () {
+    $user = freeUserSsl();
+    Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('sslCheckAvailable', false)
+        );
+});
+
+test('create form passes sslCheckAvailable=true for pro user regardless of ssl monitors count', function () {
+    $user = proUserSsl();
+    Monitor::factory()->count(5)->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('sslCheckAvailable', true)
+        );
+});
+
+// ─── Store (create) ───────────────────────────────────────────────────────────
+
+test('free user can create a monitor with ssl enabled when slot is available', function () {
+    $user = freeUserSsl();
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), monitorPayload(sslEnabled: true))
+        ->assertRedirect(route('dashboard'));
+
+    expect($user->monitors()->where('ssl_check_enabled', true)->count())->toBe(1);
+});
+
+test('free user cannot create a second monitor with ssl enabled', function () {
+    $user = freeUserSsl();
+    Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), monitorPayload(sslEnabled: true))
+        ->assertSessionHasErrors('ssl_check_enabled');
+
+    expect($user->monitors()->where('ssl_check_enabled', true)->count())->toBe(1);
+});
+
+test('free user can create a monitor with ssl disabled even when slot is used', function () {
+    $user = freeUserSsl();
+    Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), monitorPayload(sslEnabled: false))
+        ->assertRedirect(route('dashboard'));
+});
+
+test('pro user can create multiple monitors with ssl enabled', function () {
+    $user = proUserSsl();
+
+    foreach (range(1, 3) as $_) {
+        $this->actingAs($user)
+            ->post(route('monitors.store'), monitorPayload(sslEnabled: true))
+            ->assertRedirect(route('dashboard'));
+    }
+
+    expect($user->monitors()->where('ssl_check_enabled', true)->count())->toBe(3);
+});
+
+// ─── Edit form ────────────────────────────────────────────────────────────────
+
+test('edit form passes sslCheckAvailable=true when free user has ssl slot', function () {
+    $user = freeUserSsl();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => false]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('sslCheckAvailable', true)
+        );
+});
+
+test('edit form passes sslCheckAvailable=false when slot is taken by another monitor', function () {
+    $user = freeUserSsl();
+    Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => false]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('sslCheckAvailable', false)
+        );
+});
+
+test('edit form passes sslCheckAvailable=true for monitor that already has ssl enabled', function () {
+    $user = freeUserSsl();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('sslCheckAvailable', true)
+        );
+});
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+function updatePayload(Monitor $monitor, bool $sslEnabled): array
+{
+    return [
+        'name'                 => $monitor->name ?? 'Test',
+        'url'                  => $monitor->url,
+        'method'               => $monitor->method,
+        'interval_minutes'     => 5,
+        'ssl_check_enabled'    => $sslEnabled,
+        'ssl_expiry_alert_days' => $monitor->ssl_expiry_alert_days,
+    ];
+}
+
+test('free user can enable ssl on a monitor when slot is available', function () {
+    $user = freeUserSsl();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => false]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), updatePayload($monitor, sslEnabled: true))
+        ->assertRedirect(route('dashboard'));
+
+    expect($monitor->fresh()->ssl_check_enabled)->toBeTrue();
+});
+
+test('free user cannot enable ssl on a second monitor when slot is taken', function () {
+    $user = freeUserSsl();
+    Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => false]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), updatePayload($monitor, sslEnabled: true))
+        ->assertSessionHasErrors('ssl_check_enabled');
+
+    expect($monitor->fresh()->ssl_check_enabled)->toBeFalse();
+});
+
+test('free user can keep ssl enabled on a monitor that already has it', function () {
+    $user = freeUserSsl();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), updatePayload($monitor, sslEnabled: true))
+        ->assertRedirect(route('dashboard'));
+
+    expect($monitor->fresh()->ssl_check_enabled)->toBeTrue();
+});
+
+test('free user can disable ssl on a monitor', function () {
+    $user = freeUserSsl();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'ssl_check_enabled' => true]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), updatePayload($monitor, sslEnabled: false))
+        ->assertRedirect(route('dashboard'));
+
+    expect($monitor->fresh()->ssl_check_enabled)->toBeFalse();
+});
+
+test('pro user can enable ssl on multiple monitors', function () {
+    $user = proUserSsl();
+    $monitors = Monitor::factory()->count(3)->create(['user_id' => $user->id, 'ssl_check_enabled' => false]);
+
+    foreach ($monitors as $monitor) {
+        $this->actingAs($user)
+            ->put(route('monitors.update', $monitor), updatePayload($monitor, sslEnabled: true))
+            ->assertRedirect(route('dashboard'));
+    }
+
+    expect($user->monitors()->where('ssl_check_enabled', true)->count())->toBe(3);
+});


### PR DESCRIPTION
- Added logic to MonitorController to determine SSL check availability based on user plan limits.
- Enhanced StoreMonitorRequest and UpdateMonitorRequest to validate SSL monitor creation and updates against the user's plan.
- Updated Create and Edit monitor pages to reflect SSL check availability, disabling the option when limits are reached.
- Introduced tests to verify SSL monitor limit functionality for both free and pro users.

This update ensures users are informed about their SSL monitoring capabilities based on their subscription plan, improving user experience and compliance with plan restrictions.