### PR TITLE
 US-3.7 · Keyword Monitoring #54

### DIFF
--- a/app/Http/Controllers/Api/V1/MonitorController.php
+++ b/app/Http/Controllers/Api/V1/MonitorController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 
 /**
  * @tags Monitors
@@ -57,7 +58,11 @@ class MonitorController extends Controller
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
+            'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
         ]);
+
+        $this->validateKeywordLimitOnStore($request, $validated);
 
         $monitor = $request->user()->monitors()->create(
             $validated + ['current_status' => 'unknown']
@@ -105,7 +110,11 @@ class MonitorController extends Controller
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
+            'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
         ]);
+
+        $this->validateKeywordLimitOnUpdate($request, $monitor, $validated);
 
         $monitor->update($validated);
 
@@ -128,5 +137,48 @@ class MonitorController extends Controller
         $monitor->delete();
 
         return response()->json(null, 204);
+    }
+
+    private function validateKeywordLimitOnStore(Request $request, array $validated): void
+    {
+        if (empty($validated['keyword_check'])) {
+            return;
+        }
+
+        $maxKeyword = $request->user()->planConfig()['max_keyword_monitors'] ?? null;
+        if ($maxKeyword === null) {
+            return;
+        }
+
+        $usedKeyword = $request->user()->monitors()->whereNotNull('keyword_check')->count();
+        if ($usedKeyword >= $maxKeyword) {
+            throw ValidationException::withMessages([
+                'keyword_check' => 'Hai raggiunto il limite di monitor con keyword check per il tuo piano.',
+            ]);
+        }
+    }
+
+    private function validateKeywordLimitOnUpdate(Request $request, Monitor $monitor, array $validated): void
+    {
+        $isEnablingKeyword = ! empty($validated['keyword_check']) && empty($monitor->keyword_check);
+        if (! $isEnablingKeyword) {
+            return;
+        }
+
+        $maxKeyword = $request->user()->planConfig()['max_keyword_monitors'] ?? null;
+        if ($maxKeyword === null) {
+            return;
+        }
+
+        $usedKeyword = $request->user()->monitors()
+            ->whereNotNull('keyword_check')
+            ->where('id', '!=', $monitor->id)
+            ->count();
+
+        if ($usedKeyword >= $maxKeyword) {
+            throw ValidationException::withMessages([
+                'keyword_check' => 'Hai raggiunto il limite di monitor con keyword check per il tuo piano.',
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -47,15 +47,19 @@ class MonitorController extends Controller
         $user = $request->user();
         $plan = $user->planConfig();
         $maxSsl = $plan['max_ssl_monitors'] ?? null;
+        $maxKeyword = $plan['max_keyword_monitors'] ?? null;
 
         $sslCheckAvailable = $maxSsl === null
             || $user->monitors()->where('ssl_check_enabled', true)->count() < $maxSsl;
+        $keywordCheckAvailable = $maxKeyword === null
+            || $user->monitors()->whereNotNull('keyword_check')->count() < $maxKeyword;
 
         return Inertia::render('Monitors/Create', [
             'availableIntervals'        => $plan['intervals'],
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
             'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
             'sslCheckAvailable'         => $sslCheckAvailable,
+            'keywordCheckAvailable'     => $keywordCheckAvailable,
         ]);
     }
 
@@ -121,10 +125,14 @@ class MonitorController extends Controller
         $user = $request->user();
         $plan = $user->planConfig();
         $maxSsl = $plan['max_ssl_monitors'] ?? null;
+        $maxKeyword = $plan['max_keyword_monitors'] ?? null;
 
         $sslCheckAvailable = $monitor->ssl_check_enabled
             || $maxSsl === null
             || $user->monitors()->where('ssl_check_enabled', true)->where('id', '!=', $monitor->id)->count() < $maxSsl;
+        $keywordCheckAvailable = filled($monitor->keyword_check)
+            || $maxKeyword === null
+            || $user->monitors()->whereNotNull('keyword_check')->where('id', '!=', $monitor->id)->count() < $maxKeyword;
 
         return Inertia::render('Monitors/Edit', [
             'monitor'            => [
@@ -137,6 +145,8 @@ class MonitorController extends Controller
                 'is_paused'              => $monitor->is_paused,
                 'confirmation_threshold'     => $monitor->confirmation_threshold,
                 'response_time_threshold_ms' => $monitor->response_time_threshold_ms,
+                'keyword_check'              => $monitor->keyword_check,
+                'keyword_check_type'         => $monitor->keyword_check_type,
                 'ssl_check_enabled'          => $monitor->ssl_check_enabled,
                 'ssl_expiry_alert_days'      => $monitor->ssl_expiry_alert_days,
             ],
@@ -144,6 +154,7 @@ class MonitorController extends Controller
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
             'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
             'sslCheckAvailable'         => $sslCheckAvailable,
+            'keywordCheckAvailable'     => $keywordCheckAvailable,
         ]);
     }
 

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -15,20 +15,30 @@ class StoreMonitorRequest extends FormRequest
     public function withValidator($validator): void
     {
         $validator->after(function ($validator) {
-            if (! $this->boolean('ssl_check_enabled')) {
-                return;
+            if ($this->boolean('ssl_check_enabled')) {
+                $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
+
+                if ($maxSsl !== null) {
+                    $used = $this->user()->monitors()->where('ssl_check_enabled', true)->count();
+
+                    if ($used >= $maxSsl) {
+                        $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+                    }
+                }
             }
 
-            $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
+            if ($this->filled('keyword_check')) {
+                $maxKeyword = $this->user()->planConfig()['max_keyword_monitors'] ?? null;
 
-            if ($maxSsl === null) {
-                return;
-            }
+                if ($maxKeyword === null) {
+                    return;
+                }
 
-            $used = $this->user()->monitors()->where('ssl_check_enabled', true)->count();
+                $usedKeyword = $this->user()->monitors()->whereNotNull('keyword_check')->count();
 
-            if ($used >= $maxSsl) {
-                $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+                if ($usedKeyword >= $maxKeyword) {
+                    $validator->errors()->add('keyword_check', 'Hai raggiunto il limite di monitor con keyword check per il tuo piano.');
+                }
             }
         });
     }
@@ -49,6 +59,8 @@ class StoreMonitorRequest extends FormRequest
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
+            'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
             'ssl_check_enabled'    => ['boolean'],
             'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
         ];

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -15,30 +15,41 @@ class UpdateMonitorRequest extends FormRequest
     public function withValidator($validator): void
     {
         $validator->after(function ($validator) {
-            if (! $this->boolean('ssl_check_enabled')) {
-                return;
-            }
-
             /** @var \App\Models\Monitor $monitor */
             $monitor = $this->route('monitor');
 
-            if ($monitor->ssl_check_enabled) {
+            if ($this->boolean('ssl_check_enabled') && ! $monitor->ssl_check_enabled) {
+                $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
+
+                if ($maxSsl !== null) {
+                    $used = $this->user()->monitors()
+                        ->where('ssl_check_enabled', true)
+                        ->where('id', '!=', $monitor->id)
+                        ->count();
+
+                    if ($used >= $maxSsl) {
+                        $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+                    }
+                }
+            }
+
+            $isEnablingKeyword = $this->filled('keyword_check') && empty($monitor->keyword_check);
+            if (! $isEnablingKeyword) {
                 return;
             }
 
-            $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
-
-            if ($maxSsl === null) {
+            $maxKeyword = $this->user()->planConfig()['max_keyword_monitors'] ?? null;
+            if ($maxKeyword === null) {
                 return;
             }
 
-            $used = $this->user()->monitors()
-                ->where('ssl_check_enabled', true)
+            $usedKeyword = $this->user()->monitors()
+                ->whereNotNull('keyword_check')
                 ->where('id', '!=', $monitor->id)
                 ->count();
 
-            if ($used >= $maxSsl) {
-                $validator->errors()->add('ssl_check_enabled', 'Hai raggiunto il limite di monitor SSL per il tuo piano.');
+            if ($usedKeyword >= $maxKeyword) {
+                $validator->errors()->add('keyword_check', 'Hai raggiunto il limite di monitor con keyword check per il tuo piano.');
             }
         });
     }
@@ -59,6 +70,8 @@ class UpdateMonitorRequest extends FormRequest
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
                 ? ['nullable', 'integer', 'min:100']
                 : ['prohibited'],
+            'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
+            'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
             'ssl_check_enabled'     => ['boolean'],
             'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
         ];

--- a/app/Http/Resources/CheckResultResource.php
+++ b/app/Http/Resources/CheckResultResource.php
@@ -16,6 +16,7 @@ class CheckResultResource extends JsonResource
                 'status_code'      => $this->status_code,
                 'response_time_ms' => $this->response_time_ms,
                 'is_successful'    => $this->is_successful,
+                'keyword_matched'  => $this->keyword_matched,
                 'checked_at'       => $this->checked_at->toIso8601String(),
             ],
         ];

--- a/app/Http/Resources/MonitorResource.php
+++ b/app/Http/Resources/MonitorResource.php
@@ -22,6 +22,8 @@ class MonitorResource extends JsonResource
                 'confirmation_threshold'     => $this->confirmation_threshold,
                 'consecutive_failures'       => $this->consecutive_failures,
                 'response_time_threshold_ms' => $this->response_time_threshold_ms,
+                'keyword_check'              => $this->keyword_check,
+                'keyword_check_type'         => $this->keyword_check_type,
                 'last_checked_at'        => $this->last_checked_at?->toIso8601String(),
                 'created_at'             => $this->created_at->toIso8601String(),
                 'updated_at'             => $this->updated_at->toIso8601String(),

--- a/app/Jobs/PerformCheck.php
+++ b/app/Jobs/PerformCheck.php
@@ -43,6 +43,8 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
         $statusCode = null;
         $isSuccessful = false;
         $responseTimeMs = 0;
+        $keywordMatched = null;
+        $responseBody = null;
 
         try {
             $response = Http::timeout(10)->{strtolower($this->monitor->method)}($this->monitor->url);
@@ -50,6 +52,7 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
             $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
             $statusCode     = $response->status();
             $isSuccessful   = $response->successful(); // 2xx
+            $responseBody   = $response->body();
 
         } catch (ConnectionException) {
             // DNS failure, refused connection, or timeout
@@ -60,6 +63,12 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
             $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
             $statusCode     = $e->response->status();
             $isSuccessful   = false;
+            $responseBody   = $e->response->body();
+        }
+
+        if ($this->shouldRunKeywordCheck($responseBody)) {
+            $keywordMatched = $this->doesKeywordMatch($responseBody);
+            $isSuccessful   = $isSuccessful && $keywordMatched;
         }
 
         [$newStatus, $newConsecutiveFailures] = $this->resolveStatusAndCounter($isSuccessful, $oldStatus);
@@ -68,6 +77,7 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
             'status_code'      => $statusCode,
             'response_time_ms' => $responseTimeMs,
             'is_successful'    => $isSuccessful,
+            'keyword_matched'  => $keywordMatched,
             'checked_at'       => $startedAt,
         ]);
 
@@ -81,6 +91,22 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
         $this->dispatchSlowResponseIfNeeded($checkResult);
 
         CheckCompleted::dispatch($this->monitor, $checkResult);
+    }
+
+    private function shouldRunKeywordCheck(?string $responseBody): bool
+    {
+        return $responseBody !== null
+            && $this->monitor->keyword_check !== null
+            && $this->monitor->keyword_check_type !== null;
+    }
+
+    private function doesKeywordMatch(string $responseBody): bool
+    {
+        return match ($this->monitor->keyword_check_type) {
+            'contains' => str_contains($responseBody, $this->monitor->keyword_check),
+            'not_contains' => ! str_contains($responseBody, $this->monitor->keyword_check),
+            default => true,
+        };
     }
 
     /**

--- a/app/Models/CheckResult.php
+++ b/app/Models/CheckResult.php
@@ -15,6 +15,7 @@ class CheckResult extends Model
         'status_code',
         'response_time_ms',
         'is_successful',
+        'keyword_matched',
         'checked_at',
     ];
 
@@ -22,6 +23,7 @@ class CheckResult extends Model
     {
         return [
             'is_successful' => 'boolean',
+            'keyword_matched' => 'boolean',
             'checked_at'    => 'datetime',
         ];
     }

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -26,6 +26,8 @@ class Monitor extends Model
         'confirmation_threshold',
         'consecutive_failures',
         'response_time_threshold_ms',
+        'keyword_check',
+        'keyword_check_type',
         'ssl_check_enabled',
         'ssl_expiry_alert_days',
     ];
@@ -38,6 +40,8 @@ class Monitor extends Model
             'confirmation_threshold'     => 'integer',
             'consecutive_failures'       => 'integer',
             'response_time_threshold_ms' => 'integer',
+            'keyword_check'              => 'string',
+            'keyword_check_type'         => 'string',
             'ssl_check_enabled'          => 'boolean',
             'ssl_expiry_alert_days'      => 'integer',
         ];

--- a/config/plans.php
+++ b/config/plans.php
@@ -9,6 +9,7 @@ return [
         'max_confirmation_threshold' => 1,
         'response_time_alerts'       => false,
         'max_ssl_monitors'           => 1,
+        'max_keyword_monitors'       => 1,
     ],
     'pro' => [
         'max_monitors'               => null,
@@ -18,5 +19,6 @@ return [
         'max_confirmation_threshold' => 3,
         'response_time_alerts'       => true,
         'max_ssl_monitors'           => null,
+        'max_keyword_monitors'       => null,
     ],
 ];

--- a/database/factories/CheckResultFactory.php
+++ b/database/factories/CheckResultFactory.php
@@ -91,6 +91,7 @@ class CheckResultFactory extends Factory
             ]),
             'response_time_ms' => fake()->numberBetween(100, 1000),
             'is_successful'    => fake()->randomElement([true, false]),
+            'keyword_matched'  => fake()->optional()->randomElement([true, false]),
             'checked_at'       => fake()->dateTimeBetween('-1 week', 'now'),
         ];
     }

--- a/database/factories/MonitorFactory.php
+++ b/database/factories/MonitorFactory.php
@@ -25,6 +25,8 @@ class MonitorFactory extends Factory
             'confirmation_threshold'     => 1,
             'consecutive_failures'       => 0,
             'response_time_threshold_ms' => null,
+            'keyword_check'              => null,
+            'keyword_check_type'         => null,
             'ssl_check_enabled'          => false,
             'ssl_expiry_alert_days'      => 14,
         ];

--- a/database/migrations/2026_05_05_120000_add_keyword_checks_to_monitors_and_check_results.php
+++ b/database/migrations/2026_05_05_120000_add_keyword_checks_to_monitors_and_check_results.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->string('keyword_check', 255)->nullable()->after('response_time_threshold_ms');
+            $table->enum('keyword_check_type', ['contains', 'not_contains'])->nullable()->after('keyword_check');
+        });
+
+        Schema::table('check_results', function (Blueprint $table) {
+            $table->boolean('keyword_matched')->nullable()->after('is_successful');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('check_results', function (Blueprint $table) {
+            $table->dropColumn('keyword_matched');
+        });
+
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->dropColumn(['keyword_check', 'keyword_check_type']);
+        });
+    }
+};

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
     maxThreshold: number;
     responseTimeAlertsEnabled: boolean;
     sslCheckAvailable: boolean;
+    keywordCheckAvailable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -25,6 +26,8 @@ const form = useForm({
     interval_minutes:            props.availableIntervals[0],
     confirmation_threshold:      1,
     response_time_threshold_ms:  null as number | null,
+    keyword_check:               '',
+    keyword_check_type:          'contains' as 'contains' | 'not_contains',
     ssl_check_enabled:           false,
     ssl_expiry_alert_days:       14,
 });
@@ -171,6 +174,45 @@ function isIntervalLocked(minutes: number): boolean {
                                     Ricevi un alert quando la risposta supera questa soglia. Lascia vuoto per disabilitare.
                                 </p>
                                 <InputError class="mt-2" :message="form.errors.response_time_threshold_ms" />
+                            </div>
+
+                            <!-- Keyword check -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-2">
+                                    <InputLabel for="keyword_check" value="Keyword check (opzionale)" />
+                                    <ProBadge v-if="!keywordCheckAvailable" />
+                                </div>
+                                <TextInput
+                                    id="keyword_check"
+                                    type="text"
+                                    class="mt-1 block w-full"
+                                    v-model="form.keyword_check"
+                                    autocomplete="off"
+                                    placeholder="Es. Application Error"
+                                    :disabled="!keywordCheckAvailable"
+                                    :class="{ 'cursor-not-allowed opacity-50': !keywordCheckAvailable }"
+                                />
+
+                                <div v-if="keywordCheckAvailable && form.keyword_check.trim() !== ''">
+                                    <InputLabel for="keyword_check_type" value="Regola keyword" />
+                                    <select
+                                        id="keyword_check_type"
+                                        v-model="form.keyword_check_type"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    >
+                                        <option value="contains">La risposta deve contenere la keyword</option>
+                                        <option value="not_contains">La risposta NON deve contenere la keyword</option>
+                                    </select>
+                                    <InputError class="mt-2" :message="form.errors.keyword_check_type" />
+                                </div>
+
+                                <p class="text-sm text-gray-500 dark:text-gray-400">
+                                    Se valorizzato, un check HTTP 2xx viene considerato fallito quando la regola keyword non viene rispettata. Lascia vuoto per disabilitare.
+                                </p>
+                                <p v-if="!keywordCheckAvailable" class="text-sm text-amber-600 dark:text-amber-400">
+                                    Hai raggiunto il limite di monitor con keyword check del tuo piano.
+                                </p>
+                                <InputError class="mt-2" :message="form.errors.keyword_check" />
                             </div>
 
                             <!-- SSL monitoring -->

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -23,6 +23,8 @@ interface Monitor {
     is_paused: boolean;
     confirmation_threshold: number;
     response_time_threshold_ms: number | null;
+    keyword_check: string | null;
+    keyword_check_type: 'contains' | 'not_contains' | null;
     ssl_check_enabled: boolean;
     ssl_expiry_alert_days: number;
 }
@@ -33,6 +35,7 @@ const props = defineProps<{
     maxThreshold: number;
     responseTimeAlertsEnabled: boolean;
     sslCheckAvailable: boolean;
+    keywordCheckAvailable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -44,6 +47,8 @@ const form = useForm({
     interval_minutes:           props.monitor.interval_minutes,
     confirmation_threshold:     props.monitor.confirmation_threshold,
     response_time_threshold_ms: props.monitor.response_time_threshold_ms,
+    keyword_check:              props.monitor.keyword_check ?? '',
+    keyword_check_type:         (props.monitor.keyword_check_type ?? 'contains') as 'contains' | 'not_contains',
     ssl_check_enabled:          props.monitor.ssl_check_enabled,
     ssl_expiry_alert_days:      props.monitor.ssl_expiry_alert_days,
 });
@@ -209,6 +214,45 @@ function isIntervalLocked(minutes: number): boolean {
                                     Ricevi un alert quando la risposta supera questa soglia. Lascia vuoto per disabilitare.
                                 </p>
                                 <InputError class="mt-2" :message="form.errors.response_time_threshold_ms" />
+                            </div>
+
+                            <!-- Keyword check -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-2">
+                                    <InputLabel for="keyword_check" value="Keyword check (opzionale)" />
+                                    <ProBadge v-if="!keywordCheckAvailable" />
+                                </div>
+                                <TextInput
+                                    id="keyword_check"
+                                    type="text"
+                                    class="mt-1 block w-full"
+                                    v-model="form.keyword_check"
+                                    autocomplete="off"
+                                    placeholder="Es. Application Error"
+                                    :disabled="!keywordCheckAvailable && form.keyword_check.trim() === ''"
+                                    :class="{ 'cursor-not-allowed opacity-50': !keywordCheckAvailable && form.keyword_check.trim() === '' }"
+                                />
+
+                                <div v-if="form.keyword_check.trim() !== ''">
+                                    <InputLabel for="keyword_check_type" value="Regola keyword" />
+                                    <select
+                                        id="keyword_check_type"
+                                        v-model="form.keyword_check_type"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    >
+                                        <option value="contains">La risposta deve contenere la keyword</option>
+                                        <option value="not_contains">La risposta NON deve contenere la keyword</option>
+                                    </select>
+                                    <InputError class="mt-2" :message="form.errors.keyword_check_type" />
+                                </div>
+
+                                <p class="text-sm text-gray-500 dark:text-gray-400">
+                                    Se valorizzato, un check HTTP 2xx viene considerato fallito quando la regola keyword non viene rispettata. Lascia vuoto per disabilitare.
+                                </p>
+                                <p v-if="!keywordCheckAvailable && form.keyword_check.trim() === ''" class="text-sm text-amber-600 dark:text-amber-400">
+                                    Hai raggiunto il limite di monitor con keyword check del tuo piano.
+                                </p>
+                                <InputError class="mt-2" :message="form.errors.keyword_check" />
                             </div>
 
                             <!-- SSL monitoring -->

--- a/tests/Feature/Api/CheckApiTest.php
+++ b/tests/Feature/Api/CheckApiTest.php
@@ -45,7 +45,7 @@ test('check result has correct attributes shape', function () {
         ->assertOk()
         ->json('data.0.attributes');
 
-    expect($attrs)->toHaveKeys(['status_code', 'response_time_ms', 'is_successful', 'checked_at']);
+    expect($attrs)->toHaveKeys(['status_code', 'response_time_ms', 'is_successful', 'keyword_matched', 'checked_at']);
     expect($this->getJson("/api/v1/monitors/{$monitor->id}/checks")->json('data.0.type'))->toBe('check_result');
 });
 

--- a/tests/Feature/Api/MonitorApiTest.php
+++ b/tests/Feature/Api/MonitorApiTest.php
@@ -38,7 +38,19 @@ test('index response has correct attributes shape', function () {
     $response = $this->getJson('/api/v1/monitors')->assertOk();
 
     $attrs = $response->json('data.0.attributes');
-    expect($attrs)->toHaveKeys(['name', 'url', 'method', 'interval_minutes', 'current_status', 'is_paused', 'last_checked_at', 'created_at', 'updated_at']);
+    expect($attrs)->toHaveKeys([
+        'name',
+        'url',
+        'method',
+        'interval_minutes',
+        'current_status',
+        'is_paused',
+        'keyword_check',
+        'keyword_check_type',
+        'last_checked_at',
+        'created_at',
+        'updated_at',
+    ]);
     expect($response->json('data.0.type'))->toBe('monitor');
 });
 
@@ -99,6 +111,44 @@ test('store returns 403 when plan limit is reached', function () {
 
     $this->postJson('/api/v1/monitors', ['url' => 'https://extra.com', 'method' => 'GET', 'interval_minutes' => 5])
         ->assertStatus(403);
+});
+
+test('store returns 422 when free plan keyword monitor limit is reached', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+    Monitor::factory()->for($user)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    Sanctum::actingAs($user);
+
+    $this->postJson('/api/v1/monitors', [
+        'url' => 'https://extra.com',
+        'method' => 'GET',
+        'interval_minutes' => 5,
+        'keyword_check' => 'Failure',
+        'keyword_check_type' => 'contains',
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['keyword_check']);
+});
+
+test('store allows multiple keyword monitors on pro plan', function () {
+    $user = User::factory()->create(['plan' => 'pro']);
+    Monitor::factory()->for($user)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    Sanctum::actingAs($user);
+
+    $this->postJson('/api/v1/monitors', [
+        'url' => 'https://extra.com',
+        'method' => 'GET',
+        'interval_minutes' => 5,
+        'keyword_check' => 'Failure',
+        'keyword_check_type' => 'contains',
+    ])->assertStatus(201);
 });
 
 // ─── Show ──────────────────────────────────────────────────────────────────────
@@ -166,6 +216,31 @@ test('update returns 422 on invalid payload', function () {
 
     $this->putJson("/api/v1/monitors/{$monitor->id}", ['method' => 'INVALID'])
         ->assertStatus(422);
+});
+
+test('update returns 422 when free plan keyword monitor limit is reached', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+    Monitor::factory()->for($user)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+    $target = Monitor::factory()->for($user)->create([
+        'keyword_check' => null,
+        'keyword_check_type' => null,
+        'interval_minutes' => 5,
+    ]);
+
+    Sanctum::actingAs($user);
+
+    $this->putJson("/api/v1/monitors/{$target->id}", [
+        'url' => $target->url,
+        'method' => $target->method,
+        'interval_minutes' => $target->interval_minutes,
+        'keyword_check' => 'Failure',
+        'keyword_check_type' => 'contains',
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['keyword_check']);
 });
 
 // ─── Destroy ───────────────────────────────────────────────────────────────────

--- a/tests/Feature/MonitorCrudTest.php
+++ b/tests/Feature/MonitorCrudTest.php
@@ -117,6 +117,43 @@ test('pro user can create monitors without limit', function () {
     expect($user->monitors()->count())->toBe(26);
 });
 
+test('free user cannot create a second monitor with keyword check', function () {
+    $user = freeUser();
+    Monitor::factory()->forUser($user)->withInterval(5)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url' => 'https://example.com',
+            'method' => 'GET',
+            'interval_minutes' => 5,
+            'keyword_check' => 'Failure',
+            'keyword_check_type' => 'contains',
+        ])
+        ->assertSessionHasErrors('keyword_check');
+});
+
+test('pro user can create multiple monitors with keyword check', function () {
+    $user = proUser();
+
+    Monitor::factory()->forUser($user)->withInterval(5)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url' => 'https://example.com',
+            'method' => 'GET',
+            'interval_minutes' => 5,
+            'keyword_check' => 'Failure',
+            'keyword_check_type' => 'contains',
+        ])
+        ->assertRedirect(route('dashboard'));
+});
+
 // ─── Edit ─────────────────────────────────────────────────────────────────────
 
 test('owner can view the edit form pre-populated', function () {
@@ -187,6 +224,30 @@ test('non-owner cannot update monitor', function () {
             'interval_minutes' => 5,
         ])
         ->assertForbidden();
+});
+
+test('free user cannot enable keyword check on second monitor via update', function () {
+    $user = freeUser();
+
+    Monitor::factory()->forUser($user)->withInterval(5)->create([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    $target = Monitor::factory()->forUser($user)->withInterval(5)->create([
+        'keyword_check' => null,
+        'keyword_check_type' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $target), [
+            'url' => $target->url,
+            'method' => $target->method,
+            'interval_minutes' => $target->interval_minutes,
+            'keyword_check' => 'Failure',
+            'keyword_check_type' => 'contains',
+        ])
+        ->assertSessionHasErrors('keyword_check');
 });
 
 // ─── Delete ───────────────────────────────────────────────────────────────────

--- a/tests/Feature/PerformCheckTest.php
+++ b/tests/Feature/PerformCheckTest.php
@@ -117,6 +117,72 @@ test('saves null status_code and marks monitor down on timeout', function () {
     expect($monitor->refresh()->current_status)->toBe('down');
 });
 
+test('marks check as failed when contains keyword is missing on 200 response', function () {
+    Http::fake(['*' => Http::response('All systems operational', 200)]);
+
+    $monitor = monitorFor();
+    $monitor->update([
+        'keyword_check' => 'Error',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    (new PerformCheck($monitor->fresh()))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->status_code)->toBe(200)
+        ->and($result->keyword_matched)->toBeFalse()
+        ->and($result->is_successful)->toBeFalse();
+
+    expect($monitor->refresh()->current_status)->toBe('down');
+});
+
+test('marks check as successful when not_contains keyword is respected on 200 response', function () {
+    Http::fake(['*' => Http::response('All systems operational', 200)]);
+
+    $monitor = monitorFor();
+    $monitor->update([
+        'keyword_check' => 'Fatal error',
+        'keyword_check_type' => 'not_contains',
+    ]);
+
+    (new PerformCheck($monitor->fresh()))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->status_code)->toBe(200)
+        ->and($result->keyword_matched)->toBeTrue()
+        ->and($result->is_successful)->toBeTrue();
+
+    expect($monitor->refresh()->current_status)->toBe('up');
+});
+
+test('does not run keyword check on timeout', function () {
+    Http::fake(['*' => fn() => throw new ConnectionException('cURL error 28: Operation timed out')]);
+
+    $monitor = monitorFor();
+    $monitor->update([
+        'keyword_check' => 'OK',
+        'keyword_check_type' => 'contains',
+    ]);
+
+    (new PerformCheck($monitor->fresh()))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->status_code)->toBeNull()
+        ->and($result->keyword_matched)->toBeNull()
+        ->and($result->is_successful)->toBeFalse();
+});
+
+test('keeps default behavior when keyword check is not configured', function () {
+    Http::fake(['*' => Http::response('Any body content', 200)]);
+
+    $monitor = monitorFor();
+    (new PerformCheck($monitor))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->keyword_matched)->toBeNull()
+        ->and($result->is_successful)->toBeTrue();
+});
+
 // ─── Job configuration ────────────────────────────────────────────────────────
 
 test('job has 3 tries', function () {


### PR DESCRIPTION
- Introduced `keyword_check` and `keyword_check_type` fields to the Monitor model and updated the database schema.
- Enhanced MonitorController to validate keyword monitor limits based on user plan configurations.
- Updated StoreMonitorRequest and UpdateMonitorRequest to include keyword check validation.
- Modified Create and Edit monitor pages to allow users to set keyword checks, with UI adjustments to indicate availability based on plan limits.
- Implemented tests to ensure proper functionality and restrictions for keyword monitoring across different user plans.

This update enhances monitoring capabilities by allowing users to specify keyword checks, improving the effectiveness of their monitoring setup.