### PR TITLE
 US-3.8 · TCP/Ping Monitoring #55

### DIFF
--- a/app/Http/Controllers/Api/V1/MonitorController.php
+++ b/app/Http/Controllers/Api/V1/MonitorController.php
@@ -51,8 +51,10 @@ class MonitorController extends Controller
 
         $validated = $request->validate([
             'name'                       => ['nullable', 'string', 'max:255'],
-            'url'                        => ['required', 'url', 'max:2048'],
-            'method'                     => ['required', 'in:GET,HEAD'],
+            'url'                        => ['required', 'string', 'max:2048'],
+            'check_type'                 => ['nullable', 'in:http,tcp,ping'],
+            'method'                     => ['nullable', 'in:GET,HEAD'],
+            'port'                       => ['nullable', 'integer', 'min:1', 'max:65535'],
             'interval_minutes'           => ['required', 'integer', 'min:' . $minInterval],
             'confirmation_threshold'     => ['nullable', 'integer', 'min:1', 'max:' . $maxThreshold],
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
@@ -62,7 +64,10 @@ class MonitorController extends Controller
             'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
         ]);
 
+        $this->validateCheckTypePayload($validated);
+        $this->validateCheckTypePlanLimit($request, $validated);
         $this->validateKeywordLimitOnStore($request, $validated);
+        $validated = $this->normalizeCheckPayload($validated);
 
         $monitor = $request->user()->monitors()->create(
             $validated + ['current_status' => 'unknown']
@@ -103,8 +108,10 @@ class MonitorController extends Controller
 
         $validated = $request->validate([
             'name'                       => ['nullable', 'string', 'max:255'],
-            'url'                        => ['required', 'url', 'max:2048'],
-            'method'                     => ['required', 'in:GET,HEAD'],
+            'url'                        => ['required', 'string', 'max:2048'],
+            'check_type'                 => ['nullable', 'in:http,tcp,ping'],
+            'method'                     => ['nullable', 'in:GET,HEAD'],
+            'port'                       => ['nullable', 'integer', 'min:1', 'max:65535'],
             'interval_minutes'           => ['required', 'integer', 'min:' . $minInterval],
             'confirmation_threshold'     => ['nullable', 'integer', 'min:1', 'max:' . $maxThreshold],
             'response_time_threshold_ms' => $responseTimeAlertsAllowed
@@ -114,7 +121,10 @@ class MonitorController extends Controller
             'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
         ]);
 
+        $this->validateCheckTypePayload($validated);
+        $this->validateCheckTypePlanLimitOnUpdate($request, $monitor, $validated);
         $this->validateKeywordLimitOnUpdate($request, $monitor, $validated);
+        $validated = $this->normalizeCheckPayload($validated);
 
         $monitor->update($validated);
 
@@ -145,6 +155,12 @@ class MonitorController extends Controller
             return;
         }
 
+        if (($validated['check_type'] ?? 'http') !== 'http') {
+            throw ValidationException::withMessages([
+                'keyword_check' => 'Il keyword check è disponibile solo per monitor HTTP.',
+            ]);
+        }
+
         $maxKeyword = $request->user()->planConfig()['max_keyword_monitors'] ?? null;
         if ($maxKeyword === null) {
             return;
@@ -165,6 +181,12 @@ class MonitorController extends Controller
             return;
         }
 
+        if (($validated['check_type'] ?? 'http') !== 'http') {
+            throw ValidationException::withMessages([
+                'keyword_check' => 'Il keyword check è disponibile solo per monitor HTTP.',
+            ]);
+        }
+
         $maxKeyword = $request->user()->planConfig()['max_keyword_monitors'] ?? null;
         if ($maxKeyword === null) {
             return;
@@ -180,5 +202,68 @@ class MonitorController extends Controller
                 'keyword_check' => 'Hai raggiunto il limite di monitor con keyword check per il tuo piano.',
             ]);
         }
+    }
+
+    private function validateCheckTypePlanLimit(Request $request, array $validated): void
+    {
+        $checkType = $validated['check_type'] ?? 'http';
+        $allowed   = $request->user()->planConfig()['allowed_check_types'] ?? ['http', 'ping', 'tcp'];
+
+        if (! in_array($checkType, $allowed, true)) {
+            throw ValidationException::withMessages([
+                'check_type' => 'Il tipo di check selezionato non è disponibile per il tuo piano.',
+            ]);
+        }
+    }
+
+    private function validateCheckTypePlanLimitOnUpdate(Request $request, Monitor $monitor, array $validated): void
+    {
+        $checkType = $validated['check_type'] ?? 'http';
+
+        if ($checkType === $monitor->check_type) {
+            return;
+        }
+
+        $allowed = $request->user()->planConfig()['allowed_check_types'] ?? ['http', 'ping', 'tcp'];
+
+        if (! in_array($checkType, $allowed, true)) {
+            throw ValidationException::withMessages([
+                'check_type' => 'Il tipo di check selezionato non è disponibile per il tuo piano.',
+            ]);
+        }
+    }
+
+    private function validateCheckTypePayload(array $validated): void
+    {
+        $checkType = $validated['check_type'] ?? 'http';
+
+        if ($checkType === 'http') {
+            if (! filter_var($validated['url'], FILTER_VALIDATE_URL)) {
+                throw ValidationException::withMessages(['url' => 'The url field must be a valid URL.']);
+            }
+
+            if (! in_array($validated['method'] ?? null, ['GET', 'HEAD'], true)) {
+                throw ValidationException::withMessages(['method' => 'The method field is required for HTTP checks.']);
+            }
+        }
+
+        if ($checkType === 'tcp' && empty($validated['port'])) {
+            throw ValidationException::withMessages(['port' => 'The port field is required for TCP checks.']);
+        }
+    }
+
+    private function normalizeCheckPayload(array $payload): array
+    {
+        $payload['check_type'] = $payload['check_type'] ?? 'http';
+
+        if ($payload['check_type'] !== 'http') {
+            $payload['method'] = 'GET';
+        }
+
+        if ($payload['check_type'] !== 'tcp') {
+            $payload['port'] = null;
+        }
+
+        return $payload;
     }
 }

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -28,6 +28,8 @@ class MonitorController extends Controller
                 'name'                  => $monitor->name,
                 'url'                   => $monitor->url,
                 'method'                => $monitor->method,
+                'check_type'            => $monitor->check_type,
+                'port'                  => $monitor->port,
                 'interval_minutes'      => $monitor->interval_minutes,
                 'current_status'        => $monitor->current_status,
                 'is_paused'             => $monitor->is_paused,
@@ -60,13 +62,16 @@ class MonitorController extends Controller
             'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
             'sslCheckAvailable'         => $sslCheckAvailable,
             'keywordCheckAvailable'     => $keywordCheckAvailable,
+            'allowedCheckTypes'         => $plan['allowed_check_types'] ?? ['http', 'ping', 'tcp'],
         ]);
     }
 
     public function store(StoreMonitorRequest $request): RedirectResponse
     {
+        $payload = $this->normalizeCheckPayload($request->validated());
+
         $request->user()->monitors()->create(
-            $request->validated() + ['current_status' => 'unknown']
+            $payload + ['current_status' => 'unknown']
         );
 
         return redirect()->route('dashboard')
@@ -98,6 +103,8 @@ class MonitorController extends Controller
                 'name'             => $monitor->name,
                 'url'              => $monitor->url,
                 'method'           => $monitor->method,
+                'check_type'       => $monitor->check_type,
+                'port'             => $monitor->port,
                 'interval_minutes' => $monitor->interval_minutes,
                 'current_status'   => $monitor->current_status,
                 'is_paused'        => $monitor->is_paused,
@@ -140,6 +147,8 @@ class MonitorController extends Controller
                 'name'                   => $monitor->name,
                 'url'                    => $monitor->url,
                 'method'                 => $monitor->method,
+                'check_type'             => $monitor->check_type,
+                'port'                   => $monitor->port,
                 'interval_minutes'       => $monitor->interval_minutes,
                 'current_status'         => $monitor->current_status,
                 'is_paused'              => $monitor->is_paused,
@@ -155,12 +164,13 @@ class MonitorController extends Controller
             'responseTimeAlertsEnabled' => (bool) $plan['response_time_alerts'],
             'sslCheckAvailable'         => $sslCheckAvailable,
             'keywordCheckAvailable'     => $keywordCheckAvailable,
+            'allowedCheckTypes'         => $plan['allowed_check_types'] ?? ['http', 'ping', 'tcp'],
         ]);
     }
 
     public function update(UpdateMonitorRequest $request, Monitor $monitor): RedirectResponse
     {
-        $monitor->update($request->validated());
+        $monitor->update($this->normalizeCheckPayload($request->validated()));
 
         return redirect()->route('dashboard')
             ->with('message', 'Monitor aggiornato con successo.');
@@ -224,5 +234,20 @@ class MonitorController extends Controller
             ->values();
 
         return response()->json(['data' => $data]);
+    }
+
+    private function normalizeCheckPayload(array $payload): array
+    {
+        $payload['check_type'] = $payload['check_type'] ?? 'http';
+
+        if ($payload['check_type'] !== 'http') {
+            $payload['method'] = 'GET';
+        }
+
+        if ($payload['check_type'] !== 'tcp') {
+            $payload['port'] = null;
+        }
+
+        return $payload;
     }
 }

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -15,6 +15,28 @@ class StoreMonitorRequest extends FormRequest
     public function withValidator($validator): void
     {
         $validator->after(function ($validator) {
+            $checkType = $this->input('check_type', 'http');
+            $allowedCheckTypes = $this->user()->planConfig()['allowed_check_types'] ?? ['http', 'ping', 'tcp'];
+
+            if (! in_array($checkType, $allowedCheckTypes, true)) {
+                $validator->errors()->add('check_type', 'Il tipo di check selezionato non è disponibile per il tuo piano.');
+                return;
+            }
+
+            if ($checkType === 'http') {
+                if (! filter_var($this->input('url'), FILTER_VALIDATE_URL)) {
+                    $validator->errors()->add('url', 'The url field must be a valid URL.');
+                }
+
+                if (! in_array($this->input('method'), ['GET', 'HEAD'], true)) {
+                    $validator->errors()->add('method', 'The method field is required for HTTP checks.');
+                }
+            }
+
+            if ($checkType === 'tcp' && ! is_numeric($this->input('port'))) {
+                $validator->errors()->add('port', 'The port field is required for TCP checks.');
+            }
+
             if ($this->boolean('ssl_check_enabled')) {
                 $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
 
@@ -28,6 +50,11 @@ class StoreMonitorRequest extends FormRequest
             }
 
             if ($this->filled('keyword_check')) {
+                if ($checkType !== 'http') {
+                    $validator->errors()->add('keyword_check', 'Il keyword check è disponibile solo per monitor HTTP.');
+                    return;
+                }
+
                 $maxKeyword = $this->user()->planConfig()['max_keyword_monitors'] ?? null;
 
                 if ($maxKeyword === null) {
@@ -52,8 +79,10 @@ class StoreMonitorRequest extends FormRequest
 
         return [
             'name'                       => ['nullable', 'string', 'max:255'],
-            'url'                        => ['required', 'url', 'max:2048'],
-            'method'                     => ['required', 'in:GET,HEAD'],
+            'url'                        => ['required', 'string', 'max:2048'],
+            'check_type'                 => ['nullable', 'in:http,tcp,ping'],
+            'method'                     => ['nullable', 'in:GET,HEAD'],
+            'port'                       => ['nullable', 'integer', 'min:1', 'max:65535'],
             'interval_minutes'           => ['required', 'integer', 'min:'.$minInterval],
             'confirmation_threshold'     => ['nullable', 'integer', 'min:1', 'max:'.$maxThreshold],
             'response_time_threshold_ms' => $responseTimeAlertsAllowed

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -17,6 +17,32 @@ class UpdateMonitorRequest extends FormRequest
         $validator->after(function ($validator) {
             /** @var \App\Models\Monitor $monitor */
             $monitor = $this->route('monitor');
+            $checkType = $this->input('check_type', 'http');
+            $allowedCheckTypes = $this->user()->planConfig()['allowed_check_types'] ?? ['http', 'ping', 'tcp'];
+
+            if (! in_array($checkType, $allowedCheckTypes, true) && $checkType !== $monitor->check_type) {
+                $validator->errors()->add('check_type', 'Il tipo di check selezionato non è disponibile per il tuo piano.');
+                return;
+            }
+
+            if ($checkType === 'http') {
+                if (! filter_var($this->input('url'), FILTER_VALIDATE_URL)) {
+                    $validator->errors()->add('url', 'The url field must be a valid URL.');
+                }
+
+                if (! in_array($this->input('method'), ['GET', 'HEAD'], true)) {
+                    $validator->errors()->add('method', 'The method field is required for HTTP checks.');
+                }
+            }
+
+            if ($checkType === 'tcp' && ! is_numeric($this->input('port'))) {
+                $validator->errors()->add('port', 'The port field is required for TCP checks.');
+            }
+
+            if ($checkType !== 'http' && $this->filled('keyword_check')) {
+                $validator->errors()->add('keyword_check', 'Il keyword check è disponibile solo per monitor HTTP.');
+                return;
+            }
 
             if ($this->boolean('ssl_check_enabled') && ! $monitor->ssl_check_enabled) {
                 $maxSsl = $this->user()->planConfig()['max_ssl_monitors'] ?? null;
@@ -63,8 +89,10 @@ class UpdateMonitorRequest extends FormRequest
 
         return [
             'name'                       => ['nullable', 'string', 'max:255'],
-            'url'                        => ['required', 'url', 'max:2048'],
-            'method'                     => ['required', 'in:GET,HEAD'],
+            'url'                        => ['required', 'string', 'max:2048'],
+            'check_type'                 => ['nullable', 'in:http,tcp,ping'],
+            'method'                     => ['nullable', 'in:GET,HEAD'],
+            'port'                       => ['nullable', 'integer', 'min:1', 'max:65535'],
             'interval_minutes'           => ['required', 'integer', 'min:'.$minInterval],
             'confirmation_threshold'     => ['nullable', 'integer', 'min:1', 'max:'.$maxThreshold],
             'response_time_threshold_ms' => $responseTimeAlertsAllowed

--- a/app/Http/Resources/MonitorResource.php
+++ b/app/Http/Resources/MonitorResource.php
@@ -16,6 +16,8 @@ class MonitorResource extends JsonResource
                 'name'                   => $this->name,
                 'url'                    => $this->url,
                 'method'                 => $this->method,
+                'check_type'             => $this->check_type,
+                'port'                   => $this->port,
                 'interval_minutes'       => $this->interval_minutes,
                 'current_status'         => $this->current_status,
                 'is_paused'              => $this->is_paused,

--- a/app/Jobs/PerformCheck.php
+++ b/app/Jobs/PerformCheck.php
@@ -7,12 +7,10 @@ use App\Events\MonitorSlowResponse;
 use App\Events\MonitorStatusChanged;
 use App\Models\CheckResult;
 use App\Models\Monitor;
+use App\Services\Checks\CheckStrategyResolver;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Facades\Http;
 
 class PerformCheck implements ShouldQueue, ShouldBeUnique
 {
@@ -39,43 +37,21 @@ class PerformCheck implements ShouldQueue, ShouldBeUnique
     {
         $oldStatus  = $this->monitor->current_status;
         $startedAt  = now();
-        $startNs    = hrtime(true);
-        $statusCode = null;
-        $isSuccessful = false;
-        $responseTimeMs = 0;
         $keywordMatched = null;
-        $responseBody = null;
+        $strategy = app(CheckStrategyResolver::class)->resolve($this->monitor);
+        $executionResult = $strategy->run($this->monitor);
+        $isSuccessful = $executionResult->isSuccessful;
 
-        try {
-            $response = Http::timeout(10)->{strtolower($this->monitor->method)}($this->monitor->url);
-
-            $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
-            $statusCode     = $response->status();
-            $isSuccessful   = $response->successful(); // 2xx
-            $responseBody   = $response->body();
-
-        } catch (ConnectionException) {
-            // DNS failure, refused connection, or timeout
-            $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
-
-        } catch (RequestException $e) {
-            // HTTP error response received (4xx / 5xx thrown by throw())
-            $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
-            $statusCode     = $e->response->status();
-            $isSuccessful   = false;
-            $responseBody   = $e->response->body();
-        }
-
-        if ($this->shouldRunKeywordCheck($responseBody)) {
-            $keywordMatched = $this->doesKeywordMatch($responseBody);
+        if ($this->shouldRunKeywordCheck($executionResult->responseBody)) {
+            $keywordMatched = $this->doesKeywordMatch($executionResult->responseBody);
             $isSuccessful   = $isSuccessful && $keywordMatched;
         }
 
         [$newStatus, $newConsecutiveFailures] = $this->resolveStatusAndCounter($isSuccessful, $oldStatus);
 
         $checkResult = $this->monitor->checkResults()->create([
-            'status_code'      => $statusCode,
-            'response_time_ms' => $responseTimeMs,
+            'status_code'      => $executionResult->statusCode,
+            'response_time_ms' => $executionResult->responseTimeMs,
             'is_successful'    => $isSuccessful,
             'keyword_matched'  => $keywordMatched,
             'checked_at'       => $startedAt,

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -19,6 +19,8 @@ class Monitor extends Model
         'name',
         'url',
         'method',
+        'check_type',
+        'port',
         'interval_minutes',
         'current_status',
         'is_paused',
@@ -37,6 +39,8 @@ class Monitor extends Model
         return [
             'is_paused'              => 'boolean',
             'last_checked_at'        => 'datetime',
+            'check_type'             => 'string',
+            'port'                   => 'integer',
             'confirmation_threshold'     => 'integer',
             'consecutive_failures'       => 'integer',
             'response_time_threshold_ms' => 'integer',

--- a/app/Services/Checks/CheckExecutionResult.php
+++ b/app/Services/Checks/CheckExecutionResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+final readonly class CheckExecutionResult
+{
+    public function __construct(
+        public ?int $statusCode,
+        public int $responseTimeMs,
+        public bool $isSuccessful,
+        public ?string $responseBody = null,
+    ) {}
+}

--- a/app/Services/Checks/CheckStrategy.php
+++ b/app/Services/Checks/CheckStrategy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+use App\Models\Monitor;
+
+interface CheckStrategy
+{
+    public function run(Monitor $monitor): CheckExecutionResult;
+}

--- a/app/Services/Checks/CheckStrategyResolver.php
+++ b/app/Services/Checks/CheckStrategyResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+use App\Models\Monitor;
+use InvalidArgumentException;
+
+class CheckStrategyResolver
+{
+    public function __construct(
+        private HttpCheckStrategy $httpStrategy,
+        private TcpCheckStrategy $tcpStrategy,
+        private PingCheckStrategy $pingStrategy,
+    ) {}
+
+    public function resolve(Monitor $monitor): CheckStrategy
+    {
+        return match ($monitor->check_type) {
+            'http' => $this->httpStrategy,
+            'tcp' => $this->tcpStrategy,
+            'ping' => $this->pingStrategy,
+            default => throw new InvalidArgumentException('Unsupported check type: '.$monitor->check_type),
+        };
+    }
+}

--- a/app/Services/Checks/HttpCheckStrategy.php
+++ b/app/Services/Checks/HttpCheckStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+use App\Models\Monitor;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+final class HttpCheckStrategy implements CheckStrategy
+{
+    public function run(Monitor $monitor): CheckExecutionResult
+    {
+        $startNs = hrtime(true);
+
+        try {
+            $response = Http::timeout(10)->{strtolower($monitor->method)}($monitor->url);
+
+            return new CheckExecutionResult(
+                statusCode: $response->status(),
+                responseTimeMs: (int) round((hrtime(true) - $startNs) / 1_000_000),
+                isSuccessful: $response->successful(),
+                responseBody: $response->body(),
+            );
+        } catch (ConnectionException) {
+            return new CheckExecutionResult(
+                statusCode: null,
+                responseTimeMs: (int) round((hrtime(true) - $startNs) / 1_000_000),
+                isSuccessful: false,
+                responseBody: null,
+            );
+        }
+    }
+}

--- a/app/Services/Checks/PingCheckStrategy.php
+++ b/app/Services/Checks/PingCheckStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+use App\Models\Monitor;
+
+final class PingCheckStrategy implements CheckStrategy
+{
+    public function run(Monitor $monitor): CheckExecutionResult
+    {
+        $host = $this->extractHost($monitor->url);
+        $command = sprintf('ping -c 1 -W 2 %s 2>&1', escapeshellarg($host));
+
+        $output = [];
+        $exitCode = 1;
+        @exec($command, $output, $exitCode);
+
+        $responseTimeMs = $this->extractResponseTimeMs($output);
+
+        return new CheckExecutionResult(
+            statusCode: null,
+            responseTimeMs: $responseTimeMs ?? 0,
+            isSuccessful: $exitCode === 0,
+        );
+    }
+
+    /**
+     * @param array<int, string> $output
+     */
+    private function extractResponseTimeMs(array $output): ?int
+    {
+        $text = implode("\n", $output);
+
+        if (preg_match('/time[=<]([0-9]+(?:\.[0-9]+)?)\s*ms/i', $text, $matches) !== 1) {
+            return null;
+        }
+
+        return (int) round((float) $matches[1]);
+    }
+
+    private function extractHost(string $value): string
+    {
+        $host = parse_url($value, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? $host : $value;
+    }
+}

--- a/app/Services/Checks/TcpCheckStrategy.php
+++ b/app/Services/Checks/TcpCheckStrategy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Checks;
+
+use App\Models\Monitor;
+
+final class TcpCheckStrategy implements CheckStrategy
+{
+    public function run(Monitor $monitor): CheckExecutionResult
+    {
+        $host = $this->extractHost($monitor->url);
+        $port = (int) $monitor->port;
+        $startNs = hrtime(true);
+
+        $errno = 0;
+        $errstr = '';
+        $socket = @fsockopen($host, $port, $errno, $errstr, 10);
+        $responseTimeMs = (int) round((hrtime(true) - $startNs) / 1_000_000);
+
+        if (is_resource($socket)) {
+            fclose($socket);
+
+            return new CheckExecutionResult(
+                statusCode: null,
+                responseTimeMs: $responseTimeMs,
+                isSuccessful: true,
+            );
+        }
+
+        return new CheckExecutionResult(
+            statusCode: null,
+            responseTimeMs: $responseTimeMs,
+            isSuccessful: false,
+        );
+    }
+
+    private function extractHost(string $value): string
+    {
+        $host = parse_url($value, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? $host : $value;
+    }
+}

--- a/config/plans.php
+++ b/config/plans.php
@@ -10,6 +10,7 @@ return [
         'response_time_alerts'       => false,
         'max_ssl_monitors'           => 1,
         'max_keyword_monitors'       => 1,
+        'allowed_check_types'        => ['http', 'ping'],
     ],
     'pro' => [
         'max_monitors'               => null,
@@ -20,5 +21,6 @@ return [
         'response_time_alerts'       => true,
         'max_ssl_monitors'           => null,
         'max_keyword_monitors'       => null,
+        'allowed_check_types'        => ['http', 'ping', 'tcp'],
     ],
 ];

--- a/database/factories/MonitorFactory.php
+++ b/database/factories/MonitorFactory.php
@@ -18,6 +18,8 @@ class MonitorFactory extends Factory
             'name'             => fake()->optional()->words(2, true),
             'url'              => fake()->url(),
             'method'           => fake()->randomElement(['GET', 'HEAD']),
+            'check_type'       => 'http',
+            'port'             => null,
             'interval_minutes' => fake()->randomElement([1, 2, 3, 5]),
             'current_status'   => fake()->randomElement(['unknown', 'up', 'down']),
             'is_paused'              => false,

--- a/database/migrations/2026_05_05_123000_add_check_type_and_port_to_monitors_table.php
+++ b/database/migrations/2026_05_05_123000_add_check_type_and_port_to_monitors_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->enum('check_type', ['http', 'tcp', 'ping'])->default('http')->after('method');
+            $table->unsignedSmallInteger('port')->nullable()->after('check_type');
+        });
+
+        DB::table('monitors')->whereNull('check_type')->update(['check_type' => 'http']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->dropColumn(['check_type', 'port']);
+        });
+    }
+};

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -8,7 +8,9 @@ interface Monitor {
     id: number;
     name: string | null;
     url: string;
-    method: string;
+    method: string | null;
+    check_type: 'http' | 'tcp' | 'ping';
+    port: number | null;
     interval_minutes: number;
     current_status: 'unknown' | 'up' | 'down';
     is_paused: boolean;
@@ -124,6 +126,14 @@ function getStatus(monitor: Monitor) {
         };
     }
     return statusConfig[monitor.current_status] ?? statusConfig.unknown;
+}
+
+function typeIcon(type: Monitor['check_type']): string {
+    return {
+        http: '🌐',
+        tcp: '🔌',
+        ping: '📡',
+    }[type] ?? '🌐';
 }
 
 // ─── Pause toggle ─────────────────────────────────────────────────────────────
@@ -275,10 +285,10 @@ function togglePause(event: Event, monitor: Monitor) {
                                     <!-- Nome / URL -->
                                     <td class="px-6 py-4 max-w-xs">
                                         <div class="font-medium text-gray-900 dark:text-gray-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 truncate">
-                                            {{ monitor.name ?? '—' }}
+                                            {{ typeIcon(monitor.check_type) }} {{ monitor.name ?? '—' }}
                                         </div>
                                         <div class="text-xs text-gray-400 dark:text-gray-500 truncate mt-0.5">
-                                            {{ monitor.url }}
+                                            {{ monitor.url }}<span v-if="monitor.check_type === 'tcp' && monitor.port">:{{ monitor.port }}</span>
                                         </div>
                                     </td>
 

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
     responseTimeAlertsEnabled: boolean;
     sslCheckAvailable: boolean;
     keywordCheckAvailable: boolean;
+    allowedCheckTypes: string[];
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -23,6 +24,8 @@ const form = useForm({
     name:                        '',
     url:                         '',
     method:                      'GET',
+    check_type:                  'http' as 'http' | 'tcp' | 'ping',
+    port:                        null as number | null,
     interval_minutes:            props.availableIntervals[0],
     confirmation_threshold:      1,
     response_time_threshold_ms:  null as number | null,
@@ -76,21 +79,41 @@ function isIntervalLocked(minutes: number): boolean {
 
                             <!-- URL -->
                             <div>
-                                <InputLabel for="url" value="URL" />
+                                <InputLabel for="url" :value="form.check_type === 'http' ? 'URL' : 'Host'" />
                                 <TextInput
                                     id="url"
-                                    type="url"
+                                    :type="form.check_type === 'http' ? 'url' : 'text'"
                                     class="mt-1 block w-full"
                                     v-model="form.url"
                                     required
                                     autofocus
-                                    placeholder="https://example.com"
+                                    :placeholder="form.check_type === 'http' ? 'https://example.com' : 'db.internal.local'"
                                 />
                                 <InputError class="mt-2" :message="form.errors.url" />
                             </div>
 
-                            <!-- Method -->
+                            <!-- Check type -->
                             <div>
+                                <div class="flex items-center gap-2">
+                                    <InputLabel for="check_type" value="Tipo check" />
+                                    <ProBadge v-if="!allowedCheckTypes.includes('tcp')" />
+                                </div>
+                                <select
+                                    id="check_type"
+                                    v-model="form.check_type"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                >
+                                    <option value="http">🌐 HTTP</option>
+                                    <option value="ping">📡 Ping</option>
+                                    <option value="tcp" :disabled="!allowedCheckTypes.includes('tcp')">
+                                        🔌 TCP{{ !allowedCheckTypes.includes('tcp') ? ' — Solo Piano Pro' : '' }}
+                                    </option>
+                                </select>
+                                <InputError class="mt-2" :message="form.errors.check_type" />
+                            </div>
+
+                            <!-- Method -->
+                            <div v-if="form.check_type === 'http'">
                                 <InputLabel for="method" value="Metodo HTTP" />
                                 <select
                                     id="method"
@@ -101,6 +124,22 @@ function isIntervalLocked(minutes: number): boolean {
                                     <option value="HEAD">HEAD</option>
                                 </select>
                                 <InputError class="mt-2" :message="form.errors.method" />
+                            </div>
+
+                            <!-- TCP port -->
+                            <div v-if="form.check_type === 'tcp'">
+                                <InputLabel for="port" value="Porta TCP" />
+                                <input
+                                    id="port"
+                                    type="number"
+                                    min="1"
+                                    max="65535"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    :value="form.port ?? ''"
+                                    @input="form.port = ($event.target as HTMLInputElement).value === '' ? null : Number(($event.target as HTMLInputElement).value)"
+                                    placeholder="3306"
+                                />
+                                <InputError class="mt-2" :message="form.errors.port" />
                             </div>
 
                             <!-- Interval -->
@@ -177,7 +216,7 @@ function isIntervalLocked(minutes: number): boolean {
                             </div>
 
                             <!-- Keyword check -->
-                            <div class="space-y-3">
+                            <div v-if="form.check_type === 'http'" class="space-y-3">
                                 <div class="flex items-center gap-2">
                                     <InputLabel for="keyword_check" value="Keyword check (opzionale)" />
                                     <ProBadge v-if="!keywordCheckAvailable" />

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -17,7 +17,9 @@ interface Monitor {
     id: number;
     name: string | null;
     url: string;
-    method: string;
+    method: string | null;
+    check_type: 'http' | 'tcp' | 'ping';
+    port: number | null;
     interval_minutes: number;
     current_status: string;
     is_paused: boolean;
@@ -36,6 +38,7 @@ const props = defineProps<{
     responseTimeAlertsEnabled: boolean;
     sslCheckAvailable: boolean;
     keywordCheckAvailable: boolean;
+    allowedCheckTypes: string[];
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -43,7 +46,9 @@ const isPro = props.maxThreshold > 1;
 const form = useForm({
     name:                       props.monitor.name ?? '',
     url:                        props.monitor.url,
-    method:                     props.monitor.method,
+    method:                     props.monitor.method ?? 'GET',
+    check_type:                 props.monitor.check_type,
+    port:                       props.monitor.port,
     interval_minutes:           props.monitor.interval_minutes,
     confirmation_threshold:     props.monitor.confirmation_threshold,
     response_time_threshold_ms: props.monitor.response_time_threshold_ms,
@@ -117,20 +122,43 @@ function isIntervalLocked(minutes: number): boolean {
 
                             <!-- URL -->
                             <div>
-                                <InputLabel for="url" value="URL" />
+                                <InputLabel for="url" :value="form.check_type === 'http' ? 'URL' : 'Host'" />
                                 <TextInput
                                     id="url"
-                                    type="url"
+                                    :type="form.check_type === 'http' ? 'url' : 'text'"
                                     class="mt-1 block w-full"
                                     v-model="form.url"
                                     required
-                                    placeholder="https://example.com"
+                                    :placeholder="form.check_type === 'http' ? 'https://example.com' : 'db.internal.local'"
                                 />
                                 <InputError class="mt-2" :message="form.errors.url" />
                             </div>
 
-                            <!-- Method -->
+                            <!-- Check type -->
                             <div>
+                                <div class="flex items-center gap-2">
+                                    <InputLabel for="check_type" value="Tipo check" />
+                                    <ProBadge v-if="!allowedCheckTypes.includes('tcp') && monitor.check_type !== 'tcp'" />
+                                </div>
+                                <select
+                                    id="check_type"
+                                    v-model="form.check_type"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                >
+                                    <option value="http">🌐 HTTP</option>
+                                    <option value="ping">📡 Ping</option>
+                                    <option
+                                        value="tcp"
+                                        :disabled="!allowedCheckTypes.includes('tcp') && monitor.check_type !== 'tcp'"
+                                    >
+                                        🔌 TCP{{ !allowedCheckTypes.includes('tcp') && monitor.check_type !== 'tcp' ? ' — Solo Piano Pro' : '' }}
+                                    </option>
+                                </select>
+                                <InputError class="mt-2" :message="form.errors.check_type" />
+                            </div>
+
+                            <!-- Method -->
+                            <div v-if="form.check_type === 'http'">
                                 <InputLabel for="method" value="Metodo HTTP" />
                                 <select
                                     id="method"
@@ -141,6 +169,22 @@ function isIntervalLocked(minutes: number): boolean {
                                     <option value="HEAD">HEAD</option>
                                 </select>
                                 <InputError class="mt-2" :message="form.errors.method" />
+                            </div>
+
+                            <!-- TCP port -->
+                            <div v-if="form.check_type === 'tcp'">
+                                <InputLabel for="port" value="Porta TCP" />
+                                <input
+                                    id="port"
+                                    type="number"
+                                    min="1"
+                                    max="65535"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    :value="form.port ?? ''"
+                                    @input="form.port = ($event.target as HTMLInputElement).value === '' ? null : Number(($event.target as HTMLInputElement).value)"
+                                    placeholder="3306"
+                                />
+                                <InputError class="mt-2" :message="form.errors.port" />
                             </div>
 
                             <!-- Interval -->
@@ -217,7 +261,7 @@ function isIntervalLocked(minutes: number): boolean {
                             </div>
 
                             <!-- Keyword check -->
-                            <div class="space-y-3">
+                            <div v-if="form.check_type === 'http'" class="space-y-3">
                                 <div class="flex items-center gap-2">
                                     <InputLabel for="keyword_check" value="Keyword check (opzionale)" />
                                     <ProBadge v-if="!keywordCheckAvailable" />

--- a/resources/js/Pages/Monitors/Show.vue
+++ b/resources/js/Pages/Monitors/Show.vue
@@ -24,7 +24,9 @@ interface Monitor {
     id: number;
     name: string | null;
     url: string;
-    method: string;
+    method: string | null;
+    check_type: 'http' | 'tcp' | 'ping';
+    port: number | null;
     interval_minutes: number;
     current_status: 'unknown' | 'up' | 'down';
     is_paused: boolean;
@@ -253,8 +255,16 @@ watch(metrics, (pts) => {
                             <dd class="mt-1 truncate max-w-[220px] text-gray-700 dark:text-gray-200">{{ monitor.url }}</dd>
                         </div>
                         <div>
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Tipo</dt>
+                            <dd class="mt-1 text-gray-700 dark:text-gray-200 capitalize">{{ monitor.check_type }}</dd>
+                        </div>
+                        <div v-if="monitor.check_type === 'http'">
                             <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Metodo</dt>
                             <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ monitor.method }}</dd>
+                        </div>
+                        <div v-if="monitor.check_type === 'tcp'">
+                            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Porta</dt>
+                            <dd class="mt-1 text-gray-700 dark:text-gray-200">{{ monitor.port ?? '—' }}</dd>
                         </div>
                         <div>
                             <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Intervallo</dt>

--- a/tests/Feature/Api/MonitorApiTest.php
+++ b/tests/Feature/Api/MonitorApiTest.php
@@ -42,6 +42,8 @@ test('index response has correct attributes shape', function () {
         'name',
         'url',
         'method',
+        'check_type',
+        'port',
         'interval_minutes',
         'current_status',
         'is_paused',
@@ -100,6 +102,32 @@ test('store returns 422 when url is not a valid url', function () {
     $this->postJson('/api/v1/monitors', ['url' => 'not-a-url', 'method' => 'GET', 'interval_minutes' => 5])
         ->assertStatus(422)
         ->assertJsonPath('errors.url.0', fn ($v) => str_contains($v, 'url'));
+});
+
+test('store allows tcp monitor with required port', function () {
+    Sanctum::actingAs(User::factory()->create(['plan' => 'pro']));
+
+    $this->postJson('/api/v1/monitors', [
+        'url' => 'db.internal.local',
+        'check_type' => 'tcp',
+        'port' => 5432,
+        'interval_minutes' => 5,
+    ])
+        ->assertStatus(201)
+        ->assertJsonPath('data.attributes.check_type', 'tcp')
+        ->assertJsonPath('data.attributes.port', 5432);
+});
+
+test('store returns 422 for tcp monitor without port', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $this->postJson('/api/v1/monitors', [
+        'url' => 'db.internal.local',
+        'check_type' => 'tcp',
+        'interval_minutes' => 5,
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['port']);
 });
 
 test('store returns 403 when plan limit is reached', function () {

--- a/tests/Feature/CheckTypePlanLimitTest.php
+++ b/tests/Feature/CheckTypePlanLimitTest.php
@@ -1,0 +1,237 @@
+<?php
+
+use App\Models\Monitor;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function freeUserTcp(): User
+{
+    return User::factory()->create(['plan' => 'free']);
+}
+
+function proUserTcp(): User
+{
+    return User::factory()->create(['plan' => 'pro']);
+}
+
+function tcpPayload(array $overrides = []): array
+{
+    return array_merge([
+        'url'              => 'db.internal.local',
+        'check_type'       => 'tcp',
+        'port'             => 5432,
+        'interval_minutes' => 5,
+    ], $overrides);
+}
+
+function pingPayload(array $overrides = []): array
+{
+    return array_merge([
+        'url'              => '8.8.8.8',
+        'check_type'       => 'ping',
+        'interval_minutes' => 5,
+    ], $overrides);
+}
+
+// ─── Create form ──────────────────────────────────────────────────────────────
+
+test('create form passes allowedCheckTypes without tcp for free users', function () {
+    $this->actingAs(freeUserTcp())
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('allowedCheckTypes', ['http', 'ping'])
+        );
+});
+
+test('create form passes allowedCheckTypes with tcp for pro users', function () {
+    $this->actingAs(proUserTcp())
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('allowedCheckTypes', ['http', 'ping', 'tcp'])
+        );
+});
+
+// ─── Edit form ────────────────────────────────────────────────────────────────
+
+test('edit form passes allowedCheckTypes without tcp for free users', function () {
+    $user    = freeUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http']);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('allowedCheckTypes', ['http', 'ping'])
+        );
+});
+
+test('edit form passes allowedCheckTypes with tcp for pro users', function () {
+    $user    = proUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http']);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('allowedCheckTypes', ['http', 'ping', 'tcp'])
+        );
+});
+
+// ─── Web store ────────────────────────────────────────────────────────────────
+
+test('free user cannot create a tcp monitor', function () {
+    $this->actingAs(freeUserTcp())
+        ->post(route('monitors.store'), tcpPayload())
+        ->assertSessionHasErrors('check_type');
+});
+
+test('free user can create a ping monitor', function () {
+    $user = freeUserTcp();
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), pingPayload())
+        ->assertRedirect(route('dashboard'));
+
+    expect($user->monitors()->where('check_type', 'ping')->count())->toBe(1);
+});
+
+test('pro user can create a tcp monitor', function () {
+    $user = proUserTcp();
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), tcpPayload())
+        ->assertRedirect(route('dashboard'));
+
+    expect($user->monitors()->where('check_type', 'tcp')->count())->toBe(1);
+});
+
+// ─── Web update ───────────────────────────────────────────────────────────────
+
+function webUpdatePayload(Monitor $monitor, string $checkType, ?int $port = null): array
+{
+    return [
+        'name'              => $monitor->name ?? 'Test',
+        'url'               => $monitor->url,
+        'method'            => 'GET',
+        'check_type'        => $checkType,
+        'port'              => $port,
+        'interval_minutes'  => 5,
+        'ssl_expiry_alert_days' => 14,
+    ];
+}
+
+test('free user cannot switch an existing http monitor to tcp', function () {
+    $user    = freeUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http']);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), webUpdatePayload($monitor, 'tcp', 3306))
+        ->assertSessionHasErrors('check_type');
+
+    expect($monitor->fresh()->check_type)->toBe('http');
+});
+
+test('free user can keep an http monitor as http', function () {
+    $user    = freeUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http',
+        'url' => 'https://example.com', 'method' => 'GET']);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), webUpdatePayload($monitor, 'http'))
+        ->assertRedirect(route('dashboard'));
+});
+
+test('free user can keep a ping monitor as ping', function () {
+    $user    = freeUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'ping',
+        'url' => '8.8.8.8']);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), webUpdatePayload($monitor, 'ping'))
+        ->assertRedirect(route('dashboard'));
+});
+
+test('pro user can switch an http monitor to tcp', function () {
+    $user    = proUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http']);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), webUpdatePayload($monitor, 'tcp', 3306))
+        ->assertRedirect(route('dashboard'));
+
+    expect($monitor->fresh()->check_type)->toBe('tcp');
+});
+
+// ─── API store ────────────────────────────────────────────────────────────────
+
+test('free user cannot create a tcp monitor via api', function () {
+    Sanctum::actingAs(freeUserTcp());
+
+    $this->postJson('/api/v1/monitors', [
+        'url'              => 'db.internal.local',
+        'check_type'       => 'tcp',
+        'port'             => 5432,
+        'interval_minutes' => 5,
+    ])->assertStatus(422)
+      ->assertJsonValidationErrors(['check_type']);
+});
+
+test('free user can create a ping monitor via api', function () {
+    $user = freeUserTcp();
+    Sanctum::actingAs($user);
+
+    $this->postJson('/api/v1/monitors', [
+        'url'              => '8.8.8.8',
+        'check_type'       => 'ping',
+        'interval_minutes' => 5,
+    ])->assertStatus(201)
+      ->assertJsonPath('data.attributes.check_type', 'ping');
+});
+
+test('pro user can create a tcp monitor via api', function () {
+    Sanctum::actingAs(proUserTcp());
+
+    $this->postJson('/api/v1/monitors', [
+        'url'              => 'db.internal.local',
+        'check_type'       => 'tcp',
+        'port'             => 5432,
+        'interval_minutes' => 5,
+    ])->assertStatus(201)
+      ->assertJsonPath('data.attributes.check_type', 'tcp');
+});
+
+// ─── API update ───────────────────────────────────────────────────────────────
+
+test('free user cannot switch monitor to tcp via api', function () {
+    $user    = freeUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http',
+        'url' => 'https://example.com', 'method' => 'GET']);
+    Sanctum::actingAs($user);
+
+    $this->putJson("/api/v1/monitors/{$monitor->id}", [
+        'url'              => 'db.internal.local',
+        'check_type'       => 'tcp',
+        'port'             => 3306,
+        'interval_minutes' => 5,
+    ])->assertStatus(422)
+      ->assertJsonValidationErrors(['check_type']);
+});
+
+test('pro user can switch monitor to tcp via api', function () {
+    $user    = proUserTcp();
+    $monitor = Monitor::factory()->create(['user_id' => $user->id, 'check_type' => 'http',
+        'url' => 'https://example.com', 'method' => 'GET']);
+    Sanctum::actingAs($user);
+
+    $this->putJson("/api/v1/monitors/{$monitor->id}", [
+        'url'              => 'db.internal.local',
+        'check_type'       => 'tcp',
+        'port'             => 3306,
+        'interval_minutes' => 5,
+    ])->assertStatus(200)
+      ->assertJsonPath('data.attributes.check_type', 'tcp');
+});

--- a/tests/Feature/MonitorCrudTest.php
+++ b/tests/Feature/MonitorCrudTest.php
@@ -57,6 +57,25 @@ test('user can create a monitor with valid data', function () {
         ->and($user->monitors->first()->current_status)->toBe('unknown');
 });
 
+test('pro user can create a tcp monitor with host and port', function () {
+    $user = proUser();
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'name' => 'DB Primary',
+            'url' => 'db.internal.local',
+            'check_type' => 'tcp',
+            'port' => 3306,
+            'interval_minutes' => 5,
+        ])
+        ->assertRedirect(route('dashboard'));
+
+    $monitor = $user->monitors()->latest()->first();
+    expect($monitor->check_type)->toBe('tcp')
+        ->and($monitor->port)->toBe(3306)
+        ->and($monitor->method)->toBe('GET');
+});
+
 test('store fails with invalid url', function () {
     $this->actingAs(freeUser())
         ->post(route('monitors.store'), [

--- a/tests/Feature/PerformCheckTest.php
+++ b/tests/Feature/PerformCheckTest.php
@@ -4,6 +4,9 @@ use App\Jobs\PerformCheck;
 use App\Models\CheckResult;
 use App\Models\Monitor;
 use App\Models\User;
+use App\Services\Checks\CheckExecutionResult;
+use App\Services\Checks\CheckStrategy;
+use App\Services\Checks\CheckStrategyResolver;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
@@ -215,4 +218,68 @@ test('always updates last_checked_at even on failure', function () {
     (new PerformCheck($monitor))->handle();
 
     expect($monitor->refresh()->last_checked_at)->not->toBeNull();
+});
+
+test('uses tcp strategy result when monitor check_type is tcp', function () {
+    $monitor = monitorFor();
+    $monitor->update([
+        'check_type' => 'tcp',
+        'port' => 3306,
+    ]);
+
+    $strategy = new class implements CheckStrategy
+    {
+        public function run(Monitor $monitor): CheckExecutionResult
+        {
+            return new CheckExecutionResult(
+                statusCode: null,
+                responseTimeMs: 42,
+                isSuccessful: true,
+                responseBody: null,
+            );
+        }
+    };
+
+    $resolver = \Mockery::mock(CheckStrategyResolver::class);
+    $resolver->shouldReceive('resolve')->once()->andReturn($strategy);
+    app()->instance(CheckStrategyResolver::class, $resolver);
+
+    (new PerformCheck($monitor->fresh()))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->status_code)->toBeNull()
+        ->and($result->response_time_ms)->toBe(42)
+        ->and($result->is_successful)->toBeTrue();
+});
+
+test('uses ping strategy result when monitor check_type is ping', function () {
+    $monitor = monitorFor();
+    $monitor->update([
+        'check_type' => 'ping',
+        'port' => null,
+    ]);
+
+    $strategy = new class implements CheckStrategy
+    {
+        public function run(Monitor $monitor): CheckExecutionResult
+        {
+            return new CheckExecutionResult(
+                statusCode: null,
+                responseTimeMs: 10,
+                isSuccessful: false,
+                responseBody: null,
+            );
+        }
+    };
+
+    $resolver = \Mockery::mock(CheckStrategyResolver::class);
+    $resolver->shouldReceive('resolve')->once()->andReturn($strategy);
+    app()->instance(CheckStrategyResolver::class, $resolver);
+
+    (new PerformCheck($monitor->fresh()))->handle();
+
+    $result = CheckResult::where('monitor_id', $monitor->id)->sole();
+    expect($result->status_code)->toBeNull()
+        ->and($result->response_time_ms)->toBe(10)
+        ->and($result->is_successful)->toBeFalse();
 });


### PR DESCRIPTION
- Added `check_type` and `port` fields to the Monitor model and updated the database schema.
- Enhanced MonitorController to handle different check types (HTTP, TCP, Ping) and validate associated parameters.
- Updated StoreMonitorRequest and UpdateMonitorRequest to include validation for check type and port based on user plan limits.
- Modified frontend forms for creating and editing monitors to allow users to select check types and input ports, with UI adjustments for plan restrictions.
- Implemented new check strategies for HTTP, TCP, and Ping checks, improving the monitoring capabilities.
- Added tests to ensure proper functionality and restrictions for different check types across user plans.

This update significantly improves the monitoring system by allowing users to specify the type of checks they want to perform, enhancing flexibility and effectiveness in monitoring setups.