### PR TITLE
US-4.4 · Notification Cooldown #56

### DIFF
--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -56,6 +56,8 @@ class MonitorController extends Controller
         $keywordCheckAvailable = $maxKeyword === null
             || $user->monitors()->whereNotNull('keyword_check')->count() < $maxKeyword;
 
+        $notificationsConfigurable = (bool) ($plan['configurable_notifications'] ?? false);
+
         return Inertia::render('Monitors/Create', [
             'availableIntervals'        => $plan['intervals'],
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
@@ -63,6 +65,8 @@ class MonitorController extends Controller
             'sslCheckAvailable'         => $sslCheckAvailable,
             'keywordCheckAvailable'     => $keywordCheckAvailable,
             'allowedCheckTypes'         => $plan['allowed_check_types'] ?? ['http', 'ping', 'tcp'],
+            'notificationsConfigurable' => $notificationsConfigurable,
+            'cooldownOptions'           => $notificationsConfigurable ? [5, 10, 15, 30, 60] : [],
         ]);
     }
 
@@ -141,6 +145,8 @@ class MonitorController extends Controller
             || $maxKeyword === null
             || $user->monitors()->whereNotNull('keyword_check')->where('id', '!=', $monitor->id)->count() < $maxKeyword;
 
+        $notificationsConfigurable = (bool) ($plan['configurable_notifications'] ?? false);
+
         return Inertia::render('Monitors/Edit', [
             'monitor'            => [
                 'id'                     => $monitor->id,
@@ -156,8 +162,10 @@ class MonitorController extends Controller
                 'response_time_threshold_ms' => $monitor->response_time_threshold_ms,
                 'keyword_check'              => $monitor->keyword_check,
                 'keyword_check_type'         => $monitor->keyword_check_type,
-                'ssl_check_enabled'          => $monitor->ssl_check_enabled,
-                'ssl_expiry_alert_days'      => $monitor->ssl_expiry_alert_days,
+                'ssl_check_enabled'              => $monitor->ssl_check_enabled,
+                'ssl_expiry_alert_days'          => $monitor->ssl_expiry_alert_days,
+                'notification_cooldown_minutes'  => $monitor->notification_cooldown_minutes,
+                'recovery_bypass_cooldown'       => $monitor->recovery_bypass_cooldown,
             ],
             'availableIntervals'        => $plan['intervals'],
             'maxThreshold'              => (int) $plan['max_confirmation_threshold'],
@@ -165,6 +173,8 @@ class MonitorController extends Controller
             'sslCheckAvailable'         => $sslCheckAvailable,
             'keywordCheckAvailable'     => $keywordCheckAvailable,
             'allowedCheckTypes'         => $plan['allowed_check_types'] ?? ['http', 'ping', 'tcp'],
+            'notificationsConfigurable' => $notificationsConfigurable,
+            'cooldownOptions'           => $notificationsConfigurable ? [5, 10, 15, 30, 60] : [],
         ]);
     }
 

--- a/app/Http/Requests/StoreMonitorRequest.php
+++ b/app/Http/Requests/StoreMonitorRequest.php
@@ -90,8 +90,14 @@ class StoreMonitorRequest extends FormRequest
                 : ['prohibited'],
             'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
             'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
-            'ssl_check_enabled'    => ['boolean'],
-            'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
+            'ssl_check_enabled'              => ['boolean'],
+            'ssl_expiry_alert_days'          => ['integer', 'min:1', 'max:90'],
+            'notification_cooldown_minutes'  => $plan['configurable_notifications']
+                ? ['integer', 'in:5,10,15,30,60']
+                : ['prohibited'],
+            'recovery_bypass_cooldown'       => $plan['configurable_notifications']
+                ? ['boolean']
+                : ['prohibited'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateMonitorRequest.php
+++ b/app/Http/Requests/UpdateMonitorRequest.php
@@ -100,8 +100,14 @@ class UpdateMonitorRequest extends FormRequest
                 : ['prohibited'],
             'keyword_check'              => ['nullable', 'string', 'max:255', 'required_with:keyword_check_type'],
             'keyword_check_type'         => ['nullable', 'in:contains,not_contains', 'required_with:keyword_check'],
-            'ssl_check_enabled'     => ['boolean'],
-            'ssl_expiry_alert_days' => ['integer', 'min:1', 'max:90'],
+            'ssl_check_enabled'              => ['boolean'],
+            'ssl_expiry_alert_days'          => ['integer', 'min:1', 'max:90'],
+            'notification_cooldown_minutes'  => $plan['configurable_notifications']
+                ? ['integer', 'in:5,10,15,30,60']
+                : ['prohibited'],
+            'recovery_bypass_cooldown'       => $plan['configurable_notifications']
+                ? ['boolean']
+                : ['prohibited'],
         ];
     }
 }

--- a/app/Listeners/SendDownNotification.php
+++ b/app/Listeners/SendDownNotification.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\MonitorStatusChanged;
 use App\Notifications\MonitorDownNotification;
+use App\Services\NotificationThrottler;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 
@@ -13,9 +14,15 @@ class SendDownNotification implements ShouldQueue
 
     public string $queue = 'notifications';
 
+    public function __construct(private readonly NotificationThrottler $throttler) {}
+
     public function handle(MonitorStatusChanged $event): void
     {
         if ($event->newStatus !== 'down') {
+            return;
+        }
+
+        if (! $this->throttler->shouldSend($event->monitor)) {
             return;
         }
 
@@ -23,5 +30,7 @@ class SendDownNotification implements ShouldQueue
             $event->monitor,
             $event->checkResult,
         ));
+
+        $this->throttler->recordNotificationSent($event->monitor);
     }
 }

--- a/app/Listeners/SendRecoveryNotification.php
+++ b/app/Listeners/SendRecoveryNotification.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\MonitorStatusChanged;
 use App\Notifications\MonitorRecoveredNotification;
+use App\Services\NotificationThrottler;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 
@@ -13,9 +14,15 @@ class SendRecoveryNotification implements ShouldQueue
 
     public string $queue = 'notifications';
 
+    public function __construct(private readonly NotificationThrottler $throttler) {}
+
     public function handle(MonitorStatusChanged $event): void
     {
         if ($event->oldStatus !== 'down' || $event->newStatus !== 'up') {
+            return;
+        }
+
+        if (! $this->throttler->shouldSend($event->monitor, isRecovery: true)) {
             return;
         }
 
@@ -24,5 +31,7 @@ class SendRecoveryNotification implements ShouldQueue
             $event->checkResult,
             $event->downtimeSeconds,
         ));
+
+        $this->throttler->recordNotificationSent($event->monitor);
     }
 }

--- a/app/Listeners/SendSlowResponseNotification.php
+++ b/app/Listeners/SendSlowResponseNotification.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\MonitorSlowResponse;
 use App\Notifications\MonitorSlowResponseNotification;
+use App\Services\NotificationThrottler;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 
@@ -13,12 +14,20 @@ class SendSlowResponseNotification implements ShouldQueue
 
     public string $queue = 'notifications';
 
+    public function __construct(private readonly NotificationThrottler $throttler) {}
+
     public function handle(MonitorSlowResponse $event): void
     {
+        if (! $this->throttler->shouldSend($event->monitor)) {
+            return;
+        }
+
         $event->monitor->user->notify(new MonitorSlowResponseNotification(
             $event->monitor,
             $event->checkResult,
             $event->thresholdMs,
         ));
+
+        $this->throttler->recordNotificationSent($event->monitor);
     }
 }

--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -32,6 +32,9 @@ class Monitor extends Model
         'keyword_check_type',
         'ssl_check_enabled',
         'ssl_expiry_alert_days',
+        'notification_cooldown_minutes',
+        'last_notified_at',
+        'recovery_bypass_cooldown',
     ];
 
     protected function casts(): array
@@ -46,8 +49,11 @@ class Monitor extends Model
             'response_time_threshold_ms' => 'integer',
             'keyword_check'              => 'string',
             'keyword_check_type'         => 'string',
-            'ssl_check_enabled'          => 'boolean',
-            'ssl_expiry_alert_days'      => 'integer',
+            'ssl_check_enabled'              => 'boolean',
+            'ssl_expiry_alert_days'          => 'integer',
+            'notification_cooldown_minutes'  => 'integer',
+            'last_notified_at'               => 'datetime',
+            'recovery_bypass_cooldown'       => 'boolean',
         ];
     }
 

--- a/app/Services/NotificationThrottler.php
+++ b/app/Services/NotificationThrottler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Monitor;
+
+class NotificationThrottler
+{
+    /**
+     * Determine whether a notification should be sent for the given monitor.
+     *
+     * Recovery notifications bypass the cooldown when the monitor is configured
+     * to allow it (recovery_bypass_cooldown = true). All other notification types
+     * respect the cooldown window unconditionally.
+     */
+    public function shouldSend(Monitor $monitor, bool $isRecovery = false): bool
+    {
+        if ($isRecovery && $monitor->recovery_bypass_cooldown) {
+            return true;
+        }
+
+        if ($monitor->last_notified_at === null) {
+            return true;
+        }
+
+        return $monitor->last_notified_at
+            ->copy()
+            ->addMinutes($monitor->notification_cooldown_minutes)
+            ->isPast();
+    }
+
+    /**
+     * Record that a notification was just sent for this monitor.
+     * Updates last_notified_at to now so subsequent cooldown checks are accurate.
+     */
+    public function recordNotificationSent(Monitor $monitor): void
+    {
+        $monitor->update(['last_notified_at' => now()]);
+    }
+}

--- a/config/plans.php
+++ b/config/plans.php
@@ -11,6 +11,7 @@ return [
         'max_ssl_monitors'           => 1,
         'max_keyword_monitors'       => 1,
         'allowed_check_types'        => ['http', 'ping'],
+        'configurable_notifications' => false,
     ],
     'pro' => [
         'max_monitors'               => null,
@@ -22,5 +23,6 @@ return [
         'max_ssl_monitors'           => null,
         'max_keyword_monitors'       => null,
         'allowed_check_types'        => ['http', 'ping', 'tcp'],
+        'configurable_notifications' => true,
     ],
 ];

--- a/database/factories/MonitorFactory.php
+++ b/database/factories/MonitorFactory.php
@@ -29,8 +29,11 @@ class MonitorFactory extends Factory
             'response_time_threshold_ms' => null,
             'keyword_check'              => null,
             'keyword_check_type'         => null,
-            'ssl_check_enabled'          => false,
-            'ssl_expiry_alert_days'      => 14,
+            'ssl_check_enabled'              => false,
+            'ssl_expiry_alert_days'          => 14,
+            'notification_cooldown_minutes'  => 15,
+            'last_notified_at'               => null,
+            'recovery_bypass_cooldown'       => true,
         ];
     }
 

--- a/database/migrations/2026_05_06_100000_add_notification_cooldown_to_monitors_table.php
+++ b/database/migrations/2026_05_06_100000_add_notification_cooldown_to_monitors_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->unsignedTinyInteger('notification_cooldown_minutes')->default(15)->after('last_checked_at');
+            $table->timestamp('last_notified_at')->nullable()->after('notification_cooldown_minutes');
+            $table->boolean('recovery_bypass_cooldown')->default(true)->after('last_notified_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monitors', function (Blueprint $table) {
+            $table->dropColumn(['notification_cooldown_minutes', 'last_notified_at', 'recovery_bypass_cooldown']);
+        });
+    }
+};

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
     sslCheckAvailable: boolean;
     keywordCheckAvailable: boolean;
     allowedCheckTypes: string[];
+    cooldownOptions: number[];
+    notificationsConfigurable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -31,8 +33,10 @@ const form = useForm({
     response_time_threshold_ms:  null as number | null,
     keyword_check:               '',
     keyword_check_type:          'contains' as 'contains' | 'not_contains',
-    ssl_check_enabled:           false,
-    ssl_expiry_alert_days:       14,
+    ssl_check_enabled:              false,
+    ssl_expiry_alert_days:          14,
+    notification_cooldown_minutes:  props.notificationsConfigurable ? 15 : null as number | null,
+    recovery_bypass_cooldown:       props.notificationsConfigurable ? true : null as boolean | null,
 });
 
 const submit = () => {
@@ -293,6 +297,58 @@ function isIntervalLocked(minutes: number): boolean {
                                     </div>
                                     <InputError class="mt-2" :message="form.errors.ssl_expiry_alert_days" />
                                 </div>
+                            </div>
+
+                            <!-- Notification cooldown -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-2">
+                                    <InputLabel value="Cooldown notifiche" />
+                                    <ProBadge v-if="!notificationsConfigurable" />
+                                </div>
+
+                                <!-- Pro: fully configurable -->
+                                <template v-if="notificationsConfigurable">
+                                    <select
+                                        v-model="form.notification_cooldown_minutes"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    >
+                                        <option v-for="opt in cooldownOptions" :key="opt" :value="opt">
+                                            {{ opt }} minuti
+                                        </option>
+                                    </select>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Attendi almeno questo tempo prima di inviare una nuova notifica per lo stesso monitor.
+                                    </p>
+                                    <InputError class="mt-2" :message="form.errors.notification_cooldown_minutes" />
+
+                                    <div class="flex items-center gap-3">
+                                        <button
+                                            type="button"
+                                            role="switch"
+                                            :aria-checked="form.recovery_bypass_cooldown"
+                                            @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown"
+                                            class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                            :class="form.recovery_bypass_cooldown ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                        >
+                                            <span
+                                                class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                                                :class="form.recovery_bypass_cooldown ? 'translate-x-6' : 'translate-x-1'"
+                                            />
+                                        </button>
+                                        <InputLabel value="Recovery bypassa il cooldown" class="!mb-0 cursor-pointer" @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown" />
+                                    </div>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Se abilitato, la notifica di ripristino viene sempre inviata anche durante il cooldown.
+                                    </p>
+                                </template>
+
+                                <!-- Free: fixed values, locked -->
+                                <template v-else>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Cooldown fisso a <strong>15 minuti</strong>. La notifica di ripristino bypassa sempre il cooldown.
+                                        Passa al piano Pro per personalizzare questi valori.
+                                    </p>
+                                </template>
                             </div>
 
                             <!-- Actions -->

--- a/resources/js/Pages/Monitors/Create.vue
+++ b/resources/js/Pages/Monitors/Create.vue
@@ -325,7 +325,7 @@ function isIntervalLocked(minutes: number): boolean {
                                         <button
                                             type="button"
                                             role="switch"
-                                            :aria-checked="form.recovery_bypass_cooldown"
+                                            :aria-checked="form.recovery_bypass_cooldown ?? false"
                                             @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown"
                                             class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                                             :class="form.recovery_bypass_cooldown ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -372,7 +372,7 @@ function isIntervalLocked(minutes: number): boolean {
                                         <button
                                             type="button"
                                             role="switch"
-                                            :aria-checked="form.recovery_bypass_cooldown"
+                                            :aria-checked="form.recovery_bypass_cooldown ?? false"
                                             @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown"
                                             class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                                             :class="form.recovery_bypass_cooldown ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"

--- a/resources/js/Pages/Monitors/Edit.vue
+++ b/resources/js/Pages/Monitors/Edit.vue
@@ -29,6 +29,8 @@ interface Monitor {
     keyword_check_type: 'contains' | 'not_contains' | null;
     ssl_check_enabled: boolean;
     ssl_expiry_alert_days: number;
+    notification_cooldown_minutes: number;
+    recovery_bypass_cooldown: boolean;
 }
 
 const props = defineProps<{
@@ -39,6 +41,8 @@ const props = defineProps<{
     sslCheckAvailable: boolean;
     keywordCheckAvailable: boolean;
     allowedCheckTypes: string[];
+    cooldownOptions: number[];
+    notificationsConfigurable: boolean;
 }>();
 
 const isPro = props.maxThreshold > 1;
@@ -54,8 +58,10 @@ const form = useForm({
     response_time_threshold_ms: props.monitor.response_time_threshold_ms,
     keyword_check:              props.monitor.keyword_check ?? '',
     keyword_check_type:         (props.monitor.keyword_check_type ?? 'contains') as 'contains' | 'not_contains',
-    ssl_check_enabled:          props.monitor.ssl_check_enabled,
-    ssl_expiry_alert_days:      props.monitor.ssl_expiry_alert_days,
+    ssl_check_enabled:              props.monitor.ssl_check_enabled,
+    ssl_expiry_alert_days:          props.monitor.ssl_expiry_alert_days,
+    notification_cooldown_minutes:  props.notificationsConfigurable ? props.monitor.notification_cooldown_minutes : null as number | null,
+    recovery_bypass_cooldown:       props.notificationsConfigurable ? props.monitor.recovery_bypass_cooldown : null as boolean | null,
 });
 
 const submit = () => {
@@ -338,6 +344,58 @@ function isIntervalLocked(minutes: number): boolean {
                                     </div>
                                     <InputError class="mt-2" :message="form.errors.ssl_expiry_alert_days" />
                                 </div>
+                            </div>
+
+                            <!-- Notification cooldown -->
+                            <div class="space-y-3">
+                                <div class="flex items-center gap-2">
+                                    <InputLabel value="Cooldown notifiche" />
+                                    <ProBadge v-if="!notificationsConfigurable" />
+                                </div>
+
+                                <!-- Pro: fully configurable -->
+                                <template v-if="notificationsConfigurable">
+                                    <select
+                                        v-model="form.notification_cooldown_minutes"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                                    >
+                                        <option v-for="opt in cooldownOptions" :key="opt" :value="opt">
+                                            {{ opt }} minuti
+                                        </option>
+                                    </select>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Attendi almeno questo tempo prima di inviare una nuova notifica per lo stesso monitor.
+                                    </p>
+                                    <InputError class="mt-2" :message="form.errors.notification_cooldown_minutes" />
+
+                                    <div class="flex items-center gap-3">
+                                        <button
+                                            type="button"
+                                            role="switch"
+                                            :aria-checked="form.recovery_bypass_cooldown"
+                                            @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown"
+                                            class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                            :class="form.recovery_bypass_cooldown ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"
+                                        >
+                                            <span
+                                                class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+                                                :class="form.recovery_bypass_cooldown ? 'translate-x-6' : 'translate-x-1'"
+                                            />
+                                        </button>
+                                        <InputLabel value="Recovery bypassa il cooldown" class="!mb-0 cursor-pointer" @click="form.recovery_bypass_cooldown = !form.recovery_bypass_cooldown" />
+                                    </div>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Se abilitato, la notifica di ripristino viene sempre inviata anche durante il cooldown.
+                                    </p>
+                                </template>
+
+                                <!-- Free: fixed values, locked -->
+                                <template v-else>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                                        Cooldown fisso a <strong>15 minuti</strong>. La notifica di ripristino bypassa sempre il cooldown.
+                                        Passa al piano Pro per personalizzare questi valori.
+                                    </p>
+                                </template>
                             </div>
 
                             <!-- Actions -->

--- a/tests/Feature/NotificationThrottleTest.php
+++ b/tests/Feature/NotificationThrottleTest.php
@@ -1,0 +1,453 @@
+<?php
+
+use App\Events\MonitorStatusChanged;
+use App\Events\MonitorSlowResponse;
+use App\Listeners\SendDownNotification;
+use App\Listeners\SendRecoveryNotification;
+use App\Listeners\SendSlowResponseNotification;
+use App\Models\CheckResult;
+use App\Models\Monitor;
+use App\Models\User;
+use App\Notifications\MonitorDownNotification;
+use App\Notifications\MonitorRecoveredNotification;
+use App\Notifications\MonitorSlowResponseNotification;
+use App\Services\NotificationThrottler;
+use Illuminate\Support\Facades\Notification;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function throttleMonitor_(array $attrs = []): Monitor
+{
+    return Monitor::factory()->create(array_merge(
+        ['user_id' => User::factory()],
+        $attrs,
+    ));
+}
+
+function throttleDownEvent(Monitor $monitor): MonitorStatusChanged
+{
+    $result = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 500,
+        'response_time_ms' => 100,
+        'is_successful'    => false,
+        'checked_at'       => now(),
+    ]);
+
+    return new MonitorStatusChanged($monitor, 'up', 'down', $result);
+}
+
+function throttleRecoveryEvent(Monitor $monitor): MonitorStatusChanged
+{
+    $result = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 80,
+        'is_successful'    => true,
+        'checked_at'       => now(),
+    ]);
+
+    return new MonitorStatusChanged($monitor, 'down', 'up', $result, 300);
+}
+
+function throttleSlowEvent(Monitor $monitor): MonitorSlowResponse
+{
+    $result = CheckResult::create([
+        'monitor_id'       => $monitor->id,
+        'status_code'      => 200,
+        'response_time_ms' => 3000,
+        'is_successful'    => true,
+        'checked_at'       => now(),
+    ]);
+
+    return new MonitorSlowResponse($monitor, $result, 2000);
+}
+
+// ─── NotificationThrottler unit tests ────────────────────────────────────────
+
+test('shouldSend returns true when last_notified_at is null', function () {
+    $monitor = throttleMonitor_(['last_notified_at' => null, 'notification_cooldown_minutes' => 15]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor))->toBeTrue();
+});
+
+test('shouldSend returns true when cooldown has elapsed', function () {
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(16),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor))->toBeTrue();
+});
+
+test('shouldSend returns false when still within cooldown', function () {
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(10),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor))->toBeFalse();
+});
+
+test('shouldSend returns false one second before cooldown expires', function () {
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(15)->addSeconds(5),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor))->toBeFalse();
+});
+
+test('recovery bypasses cooldown when recovery_bypass_cooldown is true', function () {
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(2),
+        'notification_cooldown_minutes' => 15,
+        'recovery_bypass_cooldown'      => true,
+    ]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor, isRecovery: true))->toBeTrue();
+});
+
+test('recovery does not bypass cooldown when recovery_bypass_cooldown is false', function () {
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(2),
+        'notification_cooldown_minutes' => 15,
+        'recovery_bypass_cooldown'      => false,
+    ]);
+
+    expect((new NotificationThrottler)->shouldSend($monitor, isRecovery: true))->toBeFalse();
+});
+
+test('recordNotificationSent updates last_notified_at', function () {
+    $monitor = throttleMonitor_(['last_notified_at' => null]);
+
+    (new NotificationThrottler)->recordNotificationSent($monitor);
+
+    expect($monitor->fresh()->last_notified_at)->not->toBeNull()
+        ->and($monitor->fresh()->last_notified_at->diffInSeconds(now()))->toBeLessThan(2);
+});
+
+// ─── Down notification cooldown ───────────────────────────────────────────────
+
+test('down notification is sent when no previous notification', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_(['last_notified_at' => null]);
+    (new SendDownNotification(new NotificationThrottler))->handle(throttleDownEvent($monitor));
+
+    Notification::assertSentTo($monitor->user, MonitorDownNotification::class);
+});
+
+test('down notification is blocked within cooldown', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(5),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    (new SendDownNotification(new NotificationThrottler))->handle(throttleDownEvent($monitor));
+
+    Notification::assertNothingSent();
+});
+
+test('down notification is sent after cooldown expires', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(20),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    (new SendDownNotification(new NotificationThrottler))->handle(throttleDownEvent($monitor));
+
+    Notification::assertSentTo($monitor->user, MonitorDownNotification::class);
+});
+
+test('down notification sending updates last_notified_at', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_(['last_notified_at' => null]);
+    (new SendDownNotification(new NotificationThrottler))->handle(throttleDownEvent($monitor));
+
+    expect($monitor->fresh()->last_notified_at)->not->toBeNull();
+});
+
+test('blocked down notification does not update last_notified_at', function () {
+    Notification::fake();
+
+    $sentAt = now()->subMinutes(5);
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => $sentAt,
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    (new SendDownNotification(new NotificationThrottler))->handle(throttleDownEvent($monitor));
+
+    // DB timestamps have second precision; compare within a 1-second tolerance
+    expect($monitor->fresh()->last_notified_at->diffInSeconds($sentAt))->toBeLessThan(2);
+});
+
+// ─── Recovery notification cooldown ──────────────────────────────────────────
+
+test('recovery notification bypasses cooldown by default', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(2),
+        'notification_cooldown_minutes' => 15,
+        'recovery_bypass_cooldown'      => true,
+    ]);
+
+    (new SendRecoveryNotification(new NotificationThrottler))->handle(throttleRecoveryEvent($monitor));
+
+    Notification::assertSentTo($monitor->user, MonitorRecoveredNotification::class);
+});
+
+test('recovery notification respects cooldown when bypass is disabled', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(2),
+        'notification_cooldown_minutes' => 15,
+        'recovery_bypass_cooldown'      => false,
+    ]);
+
+    (new SendRecoveryNotification(new NotificationThrottler))->handle(throttleRecoveryEvent($monitor));
+
+    Notification::assertNothingSent();
+});
+
+test('recovery notification updates last_notified_at when sent', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'         => null,
+        'recovery_bypass_cooldown' => true,
+    ]);
+
+    (new SendRecoveryNotification(new NotificationThrottler))->handle(throttleRecoveryEvent($monitor));
+
+    expect($monitor->fresh()->last_notified_at)->not->toBeNull();
+});
+
+// ─── Slow response notification cooldown ─────────────────────────────────────
+
+test('slow response notification is blocked within cooldown', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(3),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    (new SendSlowResponseNotification(new NotificationThrottler))->handle(throttleSlowEvent($monitor));
+
+    Notification::assertNothingSent();
+});
+
+test('slow response notification is sent when cooldown has elapsed', function () {
+    Notification::fake();
+
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(20),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    (new SendSlowResponseNotification(new NotificationThrottler))->handle(throttleSlowEvent($monitor));
+
+    Notification::assertSentTo($monitor->user, MonitorSlowResponseNotification::class);
+});
+
+// ─── Cross-type cooldown (shared last_notified_at) ───────────────────────────
+
+test('slow response notification is blocked after a recent down notification', function () {
+    Notification::fake();
+
+    // Simulate: down notification was just sent
+    $monitor = throttleMonitor_([
+        'last_notified_at'              => now()->subMinutes(3),
+        'notification_cooldown_minutes' => 15,
+    ]);
+
+    // Now slow response fires — should be blocked by the shared cooldown
+    (new SendSlowResponseNotification(new NotificationThrottler))->handle(throttleSlowEvent($monitor));
+
+    Notification::assertNothingSent();
+});
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+test('store validates notification_cooldown_minutes must be in allowed set', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'                           => 'https://example.com',
+            'method'                        => 'GET',
+            'interval_minutes'              => 5,
+            'notification_cooldown_minutes' => 20, // not in [5,10,15,30,60]
+        ])
+        ->assertSessionHasErrors('notification_cooldown_minutes');
+});
+
+test('store accepts valid notification_cooldown_minutes for pro users', function () {
+    $user = User::factory()->create(['plan' => 'pro']);
+
+    foreach ([5, 10, 15, 30, 60] as $minutes) {
+        $this->actingAs($user)
+            ->post(route('monitors.store'), [
+                'url'                           => 'https://example.com',
+                'method'                        => 'GET',
+                'interval_minutes'              => 5,
+                'notification_cooldown_minutes' => $minutes,
+            ])
+            ->assertRedirect(route('dashboard'));
+    }
+});
+
+// ─── Edit form includes cooldown values ───────────────────────────────────────
+
+test('edit form passes notification cooldown fields from monitor', function () {
+    $user    = User::factory()->create(['plan' => 'pro']);
+    $monitor = Monitor::factory()->create([
+        'user_id'                       => $user->id,
+        'notification_cooldown_minutes' => 30,
+        'recovery_bypass_cooldown'      => false,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('monitor.notification_cooldown_minutes', 30)
+            ->where('monitor.recovery_bypass_cooldown', false)
+            ->where('notificationsConfigurable', true)
+            ->has('cooldownOptions')
+        );
+});
+
+// ─── Plan gating: cooldown configurability ────────────────────────────────────
+
+test('free user cannot set notification_cooldown_minutes (prohibited)', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'                           => 'https://example.com',
+            'method'                        => 'GET',
+            'interval_minutes'              => 5,
+            'notification_cooldown_minutes' => 5,
+        ])
+        ->assertSessionHasErrors('notification_cooldown_minutes');
+});
+
+test('free user cannot set recovery_bypass_cooldown (prohibited)', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'                       => 'https://example.com',
+            'method'                    => 'GET',
+            'interval_minutes'          => 5,
+            'recovery_bypass_cooldown'  => false,
+        ])
+        ->assertSessionHasErrors('recovery_bypass_cooldown');
+});
+
+test('free user can create monitor without cooldown fields and gets defaults', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'              => 'https://example.com',
+            'method'           => 'GET',
+            'interval_minutes' => 5,
+        ])
+        ->assertRedirect(route('dashboard'));
+
+    $monitor = $user->monitors()->first();
+    expect($monitor->notification_cooldown_minutes)->toBe(15)
+        ->and($monitor->recovery_bypass_cooldown)->toBeTrue();
+});
+
+test('free user cannot update notification_cooldown_minutes on existing monitor', function () {
+    $user    = User::factory()->create(['plan' => 'free']);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->put(route('monitors.update', $monitor), [
+            'url'                           => $monitor->url,
+            'interval_minutes'              => 5,
+            'notification_cooldown_minutes' => 30,
+        ])
+        ->assertSessionHasErrors('notification_cooldown_minutes');
+});
+
+test('pro user can set custom notification_cooldown_minutes', function () {
+    $user = User::factory()->create(['plan' => 'pro']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'                           => 'https://example.com',
+            'method'                        => 'GET',
+            'interval_minutes'              => 1,
+            'notification_cooldown_minutes' => 30,
+            'recovery_bypass_cooldown'      => false,
+        ])
+        ->assertRedirect(route('dashboard'));
+
+    $monitor = $user->monitors()->first();
+    expect($monitor->notification_cooldown_minutes)->toBe(30)
+        ->and($monitor->recovery_bypass_cooldown)->toBeFalse();
+});
+
+test('pro user gets invalid error for non-allowed cooldown value', function () {
+    $user = User::factory()->create(['plan' => 'pro']);
+
+    $this->actingAs($user)
+        ->post(route('monitors.store'), [
+            'url'                           => 'https://example.com',
+            'method'                        => 'GET',
+            'interval_minutes'              => 1,
+            'notification_cooldown_minutes' => 20, // not in [5,10,15,30,60]
+        ])
+        ->assertSessionHasErrors('notification_cooldown_minutes');
+});
+
+test('create form for free user has notificationsConfigurable false and empty cooldownOptions', function () {
+    $user = User::factory()->create(['plan' => 'free']);
+
+    $this->actingAs($user)
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('notificationsConfigurable', false)
+            ->where('cooldownOptions', [])
+        );
+});
+
+test('create form for pro user has notificationsConfigurable true and full cooldownOptions', function () {
+    $user = User::factory()->create(['plan' => 'pro']);
+
+    $this->actingAs($user)
+        ->get(route('monitors.create'))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Create')
+            ->where('notificationsConfigurable', true)
+            ->where('cooldownOptions', [5, 10, 15, 30, 60])
+        );
+});
+
+test('edit form for free user has notificationsConfigurable false', function () {
+    $user    = User::factory()->create(['plan' => 'free']);
+    $monitor = Monitor::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->get(route('monitors.edit', $monitor))
+        ->assertInertia(fn ($page) => $page
+            ->component('Monitors/Edit')
+            ->where('notificationsConfigurable', false)
+            ->where('cooldownOptions', [])
+        );
+});

--- a/tests/Feature/SendDownNotificationTest.php
+++ b/tests/Feature/SendDownNotificationTest.php
@@ -35,7 +35,7 @@ test('sends notification to monitor owner when status goes down', function () {
     Notification::fake();
 
     $event = makeEvent('up', 'down');
-    (new SendDownNotification)->handle($event);
+    (new SendDownNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo($event->monitor->user, MonitorDownNotification::class);
 });
@@ -44,7 +44,7 @@ test('sends notification on first check when service is already down (unknown �
     Notification::fake();
 
     $event = makeEvent('unknown', 'down');
-    (new SendDownNotification)->handle($event);
+    (new SendDownNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo($event->monitor->user, MonitorDownNotification::class);
 });
@@ -55,7 +55,7 @@ test('does not send notification when monitor recovers (down → up)', function 
     Notification::fake();
 
     $event = makeEvent('down', 'up');
-    (new SendDownNotification)->handle($event);
+    (new SendDownNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertNothingSent();
 });
@@ -80,7 +80,7 @@ test('notification mail contains monitor name, url, status code and timestamp', 
     ]);
 
     $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
-    (new SendDownNotification)->handle($event);
+    (new SendDownNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo(
         $monitor->user,
@@ -111,7 +111,7 @@ test('notification shows "Connection failed" when status code is null', function
     ]);
 
     $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
-    (new SendDownNotification)->handle($event);
+    (new SendDownNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo(
         $monitor->user,
@@ -128,7 +128,7 @@ test('notification shows "Connection failed" when status code is null', function
 // ─── Queue ────────────────────────────────────────────────────────────────────
 
 test('listener is queued on the notifications queue', function () {
-    $listener = new SendDownNotification();
+    $listener = new SendDownNotification(new \App\Services\NotificationThrottler());
 
     expect($listener)->toBeInstanceOf(Illuminate\Contracts\Queue\ShouldQueue::class);
     expect($listener->queue)->toBe('notifications');

--- a/tests/Feature/SendRecoveryNotificationTest.php
+++ b/tests/Feature/SendRecoveryNotificationTest.php
@@ -34,7 +34,7 @@ test('sends recovery notification to monitor owner when monitor comes back up', 
     Notification::fake();
 
     $event = recoveryEvent();
-    (new SendRecoveryNotification)->handle($event);
+    (new SendRecoveryNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo($event->monitor->user, MonitorRecoveredNotification::class);
 });
@@ -54,7 +54,7 @@ test('does not send notification when monitor goes down (up → down)', function
     ]);
 
     $event = new MonitorStatusChanged($monitor, 'up', 'down', $checkResult);
-    (new SendRecoveryNotification)->handle($event);
+    (new SendRecoveryNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertNothingSent();
 });
@@ -72,7 +72,7 @@ test('does not send notification on unknown → up', function () {
     ]);
 
     $event = new MonitorStatusChanged($monitor, 'unknown', 'up', $checkResult);
-    (new SendRecoveryNotification)->handle($event);
+    (new SendRecoveryNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertNothingSent();
 });
@@ -83,7 +83,7 @@ test('notification mail contains monitor name, url, recovery timestamp and downt
     Notification::fake();
 
     $event = recoveryEvent(downtimeSeconds: 3750); // 1h 2m 30s
-    (new SendRecoveryNotification)->handle($event);
+    (new SendRecoveryNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo(
         $event->monitor->user,
@@ -104,7 +104,7 @@ test('notification omits downtime line when downtimeSeconds is null', function (
     Notification::fake();
 
     $event = recoveryEvent(downtimeSeconds: null);
-    (new SendRecoveryNotification)->handle($event);
+    (new SendRecoveryNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo(
         $event->monitor->user,
@@ -156,7 +156,7 @@ test('formats downtime in hours and minutes when over an hour', function () {
 // ─── Queue ────────────────────────────────────────────────────────────────────
 
 test('listener is queued on the notifications queue', function () {
-    $listener = new SendRecoveryNotification();
+    $listener = new SendRecoveryNotification(new \App\Services\NotificationThrottler());
 
     expect($listener)->toBeInstanceOf(ShouldQueue::class);
     expect($listener->queue)->toBe('notifications');

--- a/tests/Feature/SlowResponseTest.php
+++ b/tests/Feature/SlowResponseTest.php
@@ -99,13 +99,13 @@ test('listener sends MonitorSlowResponseNotification to monitor owner', function
     ]);
 
     $event = new MonitorSlowResponse($monitor, $result, 2000);
-    (new SendSlowResponseNotification())->handle($event);
+    (new SendSlowResponseNotification(new \App\Services\NotificationThrottler()))->handle($event);
 
     Notification::assertSentTo($user, MonitorSlowResponseNotification::class);
 });
 
 test('listener is queued on the notifications queue', function () {
-    expect((new SendSlowResponseNotification())->queue)->toBe('notifications');
+    expect((new SendSlowResponseNotification(new \App\Services\NotificationThrottler()))->queue)->toBe('notifications');
 });
 
 // ─── Notification content ─────────────────────────────────────────────────────


### PR DESCRIPTION
- Introduced a `NotificationThrottler` service to manage cooldown periods for sending notifications related to monitor status changes.
- Updated `Monitor` model to include fields for `notification_cooldown_minutes`, `last_notified_at`, and `recovery_bypass_cooldown`.
- Enhanced `SendDownNotification`, `SendRecoveryNotification`, and `SendSlowResponseNotification` listeners to utilize the throttler for controlling notification dispatch.
- Modified `MonitorController`, request validation, and frontend forms to support new notification settings based on user plans.
- Added tests to ensure proper functionality of notification throttling and cooldown behavior.

This update improves the notification system by preventing spam and allowing users to configure notification settings based on their subscription plan, enhancing user experience and control over alerts.